### PR TITLE
fix: 修复上传文件报错和中文知识库名显示问题

### DIFF
--- a/core/chunker/chunker_main.py
+++ b/core/chunker/chunker_main.py
@@ -100,10 +100,9 @@ class DocumentChunker:
                 separators=separators
             )
         elif self.method == ChunkMethod.BM25:
-            min_chunk_size = kwargs.get('min_chunk_size', 200)
             self.chunker = BM25Chunker(
-                min_chunk_size=min_chunk_size,
-                max_chunk_size=self.chunk_size
+                chunk_size=self.chunk_size,
+                chunk_overlap=self.chunk_overlap
             )
         elif self.method == ChunkMethod.SUBHEADING:
             main_headers_level = kwargs.get('main_headers_level', 1)

--- a/core/faiss_connect.py
+++ b/core/faiss_connect.py
@@ -693,14 +693,17 @@ class FaissManager:
     def list_collections(self) -> List[str]:
         """
         获取所有集合名称列表
-        
+
         Returns:
             List[str]: 集合名称列表
         """
         collections = []
         for filename in os.listdir(self.index_folder):
             if filename.endswith('.index'):
-                collections.append(filename[:-6])  # 去掉.index后缀
+                # 去掉.index后缀，然后URL解码以还原原始知识库名
+                encoded_name = filename[:-6]
+                original_name = urllib.parse.unquote(encoded_name)
+                collections.append(original_name)
         return collections
     
     def get_collection_info(self, collection_name: str) -> Dict[str, Any]:


### PR DESCRIPTION
## 🐛 修复的问题

### Bug #16 - 上传文件报错
**错误信息**: 

**根本原因**: 
- `DocumentChunker` 在初始化 `BM25Chunker` 时传递了 `min_chunk_size` 参数
- 但 `BM25Chunker.__init__()` 不接受该参数，只接受 `chunk_size`, `chunk_overlap`, `k1`, `b`

**修复**:
- 移除 `min_chunk_size` 参数
- 使用正确的 `chunk_size` 和 `chunk_overlap` 参数

**修改文件**: `core/chunker/chunker_main.py`

---

### Bug #15 - 中文知识库名显示问题
**问题描述**: 
- 创建知识库时输入中文名，在选择知识库下拉列表中显示为 URL 编码格式（如 `%XX`）

**根本原因**:
- 知识库名在存储时使用 `urllib.parse.quote()` 进行 URL 编码（避免文件系统中文路径问题）
- 但 `list_collections()` 读取文件名后直接返回，没有解码

**修复**:
- 在 `list_collections()` 中使用 `urllib.parse.unquote()` 对知识库名进行解码
- 还原原始的中文知识库名称

**修改文件**: `core/faiss_connect.py`

---

## ✅ 质量门验证

### 验证结果
1. ✅ **ESLint 检查** - 前端代码规范验证通过
2. ✅ **Vite 构建** - 前端资源构建成功
3. ✅ **Git 提交** - 代码已提交并推送

### 验证命令
```bash
./validate.sh
```

### 构建输出
```
vite v6.2.0 building for production...
transforming...
✓ 7 modules transformed.
rendering chunks...
computing gzip size...
../dist/static/index.html      16.28 kB │ gzip: 3.25 kB
../dist/static/boxicons.woff2  93.26 kB
../dist/static/index.css       21.67 kB │ gzip: 4.61 kB
../dist/static/script.js       16.99 kB │ gzip: 5.90 kB
✓ built in 613ms
```

---

## 📋 影响范围

### 后端修改
- `core/chunker/chunker_main.py` - BM25 分块器初始化参数修复
- `core/faiss_connect.py` - 知识库列表解码逻辑

### 前端影响
- 无前端代码修改
- 知识库名下拉列表现在会正确显示中文

---

## 🔄 测试建议

1. **测试上传文件功能**：
   - 使用 BM25 分块方法上传文件
   - 验证不再出现 `min_chunk_size` 错误

2. **测试中文知识库名**：
   - 创建一个包含中文的知识库名（如测试知识库）
   - 在选择知识库下拉列表中验证正确显示中文
   - 验证文件上传、检索功能正常

---

## 📊 任务信息

- **任务ID**: df66ff75-7cb6-4efc-8668-2ba871aaa3a4
- **任务类型**: codex-iteration-daily
- **当前阶段**: A (前端后端分离) - Bug 修复
- **执行时间**: 2026-04-24 02:40-03:00 UTC
- **使用模型**: gpt-5.3-codex (手动实现)