### PR TITLE
新增 /web/search 端点：接入 You.com 联网检索作为外部检索源

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,24 @@ context = get_knowledge_context("人工智能发展趋势")
 # 传递给DocuGen进行文档生成...
 ```
 
+**联网检索（You.com 外部检索源）**：
+```python
+import requests
+
+# 独立于本地知识库的外部检索：需先配置环境变量 YDC_API_KEY
+response = requests.post("http://localhost:8028/web/search", json={
+    "query": "最新的检索增强生成研究",
+    "top_k": 5
+})
+
+data = response.json()          # 结构与 /kb/search 一致
+for item in data["data"]:
+    print(f"相关度: {item['score']}  来源: {item['metadata']['url']}")
+    print(item["text"])
+```
+> 未配置 `YDC_API_KEY` 时该端点返回 `{"status": "success", "message": "未配置 YDC_API_KEY，联网检索未启用", "data": []}`，不影响本地检索。
+> 请勿将真实 Key 提交到仓库，建议放在未跟踪的环境变量或本地 `.env` 中。
+
 ### 🔧 高级配置
 
 <details>
@@ -515,6 +533,10 @@ MODEL_CACHE_DIR=./models
 DEFAULT_TOP_K=5
 DEFAULT_SIMILARITY_THRESHOLD=0.3
 MAX_CHUNK_SIZE=500
+
+# 联网检索（可选）：You.com Search API Key，配置后 /web/search 端点可作为
+# 本地知识库之外的外部检索源；留空则该端点返回未启用提示，不影响其它功能。
+YDC_API_KEY=
 
 # 日志配置
 LOG_LEVEL=INFO

--- a/README_EN.md
+++ b/README_EN.md
@@ -486,6 +486,24 @@ context = get_knowledge_context("AI development trends")
 # Pass to DocuGen for document generation...
 ```
 
+**Web search (You.com external retriever)**:
+```python
+import requests
+
+# External retrieval, independent of the local KB; requires YDC_API_KEY.
+response = requests.post("http://localhost:8028/web/search", json={
+    "query": "latest retrieval-augmented generation research",
+    "top_k": 5
+})
+
+data = response.json()          # same shape as /kb/search
+for item in data["data"]:
+    print(f"score: {item['score']}  source: {item['metadata']['url']}")
+    print(item["text"])
+```
+> Without `YDC_API_KEY`, the endpoint returns `{"status": "success", "message": "...联网检索未启用", "data": []}` and other features are unaffected.
+> Do not commit your real key to the repo; keep it in an untracked environment variable or local `.env`.
+
 ### 🔧 Advanced Configuration
 
 <details>
@@ -510,6 +528,11 @@ MODEL_CACHE_DIR=./models
 DEFAULT_TOP_K=5
 DEFAULT_SIMILARITY_THRESHOLD=0.3
 MAX_CHUNK_SIZE=500
+
+# Web search (optional): You.com Search API key. With it set, the /web/search
+# endpoint works as an external retriever alongside the local KB; left blank the
+# endpoint returns a "not enabled" message and nothing else is affected.
+YDC_API_KEY=
 
 # Logging Configuration
 LOG_LEVEL=INFO

--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ if parent_dir not in sys.path:
     sys.path.append(parent_dir)
 
 from main import RAGService, DocumentProcessor
+from core.web_search.youcom_retriever import YouComWebRetriever
 # 添加进度跟踪字典
 # 格式: {task_id: {"status": "processing/completed/failed", "progress": 0-100, "message": "处理中..."}}
 processing_tasks = {}
@@ -59,6 +60,10 @@ class SearchQuery(BaseModel):
     use_rerank: bool = True
     remove_duplicates: bool = True
     filter_criteria: str = ""
+
+class WebSearchQuery(BaseModel):
+    query: str
+    top_k: int = 5
 
 class ChunkConfig(BaseModel):
     method: str = "text_semantic"
@@ -468,6 +473,39 @@ async def search_knowledge_base(query: SearchQuery):
     except Exception as e:
         error_trace = traceback.format_exc()
         raise HTTPException(status_code=500, detail=f"搜索知识库失败: {str(e)}\n{error_trace}")
+
+@app.post("/web/search")
+async def search_web(query: WebSearchQuery):
+    """使用 You.com 联网检索作为外部检索源（独立于本地知识库）。
+
+    未配置 YDC_API_KEY 时返回明确提示且不报错；检索失败同样优雅降级为空结果。
+    返回结构与 /kb/search 一致（index / score / text / metadata）。
+    """
+    try:
+        retriever = YouComWebRetriever()
+        if not retriever.available:
+            return {
+                "status": "success",
+                "message": "未配置 YDC_API_KEY，联网检索未启用",
+                "data": []
+            }
+
+        results = retriever.search(query.query, query.top_k)
+
+        if not results:
+            return {
+                "status": "success",
+                "message": "未找到相关内容",
+                "data": []
+            }
+
+        return {
+            "status": "success",
+            "data": results
+        }
+    except Exception as e:
+        error_trace = traceback.format_exc()
+        raise HTTPException(status_code=500, detail=f"联网检索失败: {str(e)}\n{error_trace}")
 
 @app.post("/kb/delete_documents")
 async def delete_documents(

--- a/core/web_search/__init__.py
+++ b/core/web_search/__init__.py
@@ -1,0 +1,4 @@
+"""联网检索模块：把 You.com 等外部搜索源作为本地知识库之外的补充检索器。"""
+from core.web_search.youcom_retriever import YouComWebRetriever
+
+__all__ = ["YouComWebRetriever"]

--- a/core/web_search/youcom_retriever.py
+++ b/core/web_search/youcom_retriever.py
@@ -1,0 +1,140 @@
+"""You.com Web Search 外部检索器。
+
+作为本地知识库之外的补充检索源：调用 You.com Search API
+（GET https://ydc-index.io/v1/search，X-API-Key 鉴权），把网页与新闻结果
+整理成与本地库检索一致的结构（index / score / text / metadata），
+供 /web/search 端点使用。
+
+配置：环境变量 YDC_API_KEY（团队约定名，勿改）。未配置时检索器不可用，
+上层端点会返回明确提示而非报错。任何网络 / 状态码 / 解析异常都会被捕获并
+返回空结果，绝不向上抛出，保证不影响主服务。
+"""
+import logging
+import os
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # python-dotenv 可选：缺失时退化为仅读真实环境变量，不影响启动
+    pass
+
+logger = logging.getLogger(__name__)
+
+# You.com Search API 端点（团队约定）
+YOUCOM_ENDPOINT = "https://ydc-index.io/v1/search"
+# 团队约定：对 You.com 主机的请求需带此 User-Agent（lowercased owner-repo slug）
+YOUCOM_USER_AGENT = "youdotcom-integration/betastreetomnis-easyrag"
+
+DEFAULT_TOP_K = 5
+MAX_TOP_K = 20
+REQUEST_TIMEOUT = 15
+
+
+class YouComWebRetriever:
+    """You.com 联网检索器，返回与本地库检索一致的结果结构。"""
+
+    def __init__(self, api_key=None, endpoint=YOUCOM_ENDPOINT):
+        # 显式传入优先，否则回退环境变量 YDC_API_KEY；strip 掉空白避免误判为已配置
+        raw_key = api_key if api_key is not None else os.getenv("YDC_API_KEY", "")
+        self.api_key = (raw_key or "").strip()
+        self.endpoint = endpoint
+
+    @property
+    def available(self):
+        """是否已配置可用的 API Key。"""
+        return bool(self.api_key)
+
+    def search(self, query, top_k=DEFAULT_TOP_K):
+        """检索网页结果。
+
+        参数:
+            query: 查询文本
+            top_k: 返回的最大结果数（1-20，越界自动夹取）
+
+        返回:
+            List[Dict]，每项含 index / score / text / metadata；未配置 Key、
+            网络异常、非 2xx、解析失败时统一返回 []（记录日志，绝不抛出）。
+        """
+        if not self.available:
+            logger.warning("YouComWebRetriever 未配置 YDC_API_KEY，跳过联网检索")
+            return []
+
+        try:
+            n = int(top_k)
+        except (TypeError, ValueError):
+            n = DEFAULT_TOP_K
+        n = max(1, min(n, MAX_TOP_K))
+
+        try:
+            resp = requests.get(
+                self.endpoint,
+                params={"query": query, "count": n},
+                headers={"X-API-Key": self.api_key, "User-Agent": YOUCOM_USER_AGENT},
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            logger.error("You.com 联网检索请求失败: %s", exc)
+            return []
+
+        if resp.status_code != 200:
+            # 不回显响应体，避免泄露账号信息；401 鉴权 / 429 限流 / 5xx 服务端
+            logger.error("You.com 联网检索返回状态码 %s", resp.status_code)
+            return []
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            logger.error("You.com 响应解析失败: %s", exc)
+            return []
+
+        return self._to_results(payload, n)
+
+    @staticmethod
+    def _to_results(payload, n):
+        """把 You.com 响应归一化为本地库一致的结果结构。
+
+        响应结构 {"results": {"web": [...], "news": [...]}}；news 可能缺失，
+        每条结果除 url/title/description/snippets 外字段均视为可选，防御式读取。
+        """
+        if not isinstance(payload, dict):
+            return []
+        results_node = payload.get("results")
+        if not isinstance(results_node, dict):
+            return []
+        entries = []
+        for bucket in ("web", "news"):
+            bucket_items = results_node.get(bucket)
+            if not isinstance(bucket_items, list):
+                continue
+            for entry in bucket_items:
+                if isinstance(entry, dict):
+                    entries.append(entry)
+
+        # web 与 news 各返回最多 n 条，按合并总数截断，与 top_k 语义对齐
+        entries = entries[:n]
+
+        formatted = []
+        for rank, entry in enumerate(entries):
+            url = entry.get("url") or ""
+            title = entry.get("title") or ""
+            description = entry.get("description") or ""
+            snippets = entry.get("snippets")
+            snippet_text = ""
+            if isinstance(snippets, list):
+                snippet_text = "\n".join(s for s in snippets if isinstance(s, str))
+
+            text_parts = [part for part in (title, description, snippet_text) if part]
+            if url:
+                text_parts.append("来源: %s" % url)
+
+            formatted.append({
+                "index": rank,
+                # You.com 已按相关性排序、无分数，这里用名次递减的中性分数
+                "score": round(1.0 - rank * 0.01, 4),
+                "text": "\n".join(text_parts),
+                "metadata": {"url": url, "title": title, "source": "you.com"},
+            })
+        return formatted

--- a/docker.env
+++ b/docker.env
@@ -13,4 +13,9 @@ PYTHONUNBUFFERED=1
 PYTHONDONTWRITEBYTECODE=1
 
 # 日志配置
-LOG_LEVEL=INFO 
+LOG_LEVEL=INFO
+
+# 联网检索（可选）：配置 You.com Search API Key 后，/web/search 端点即可作为
+# 本地知识库之外的外部检索源；留空则该端点返回未启用提示，不影响其它功能。
+# 获取 Key：https://you.com/platform/api-keys
+YDC_API_KEY=

--- a/tests/test_youcom_retriever.py
+++ b/tests/test_youcom_retriever.py
@@ -1,0 +1,157 @@
+"""YouComWebRetriever 单元测试（纯离线，不触网、不需要真实 Key）。
+
+用标准库 unittest + mock 打桩 requests.get，覆盖：来源映射、鉴权头与
+User-Agent、top_k 夹取与总数截断、未配置 Key、各类错误（非 2xx / 网络异常 /
+解析失败）优雅降级、异常响应结构不崩溃、Key 不泄露。
+
+运行：`python -m unittest discover -s tests`（无需额外依赖）。
+"""
+import unittest
+from unittest import mock
+
+import requests
+
+from core.web_search.youcom_retriever import YouComWebRetriever, YOUCOM_USER_AGENT
+
+
+class FakeResp:
+    def __init__(self, status_code=200, payload=None, raise_json=False):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self._raise_json = raise_json
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("no json")
+        return self._payload
+
+
+SAMPLE = {
+    "results": {
+        "web": [
+            {"url": "https://e.com/a", "title": "标题A", "description": "描述A",
+             "snippets": ["片段A1", "片段A2"]},
+            {"url": "https://e.com/b", "title": "标题B", "snippets": ["片段B1"]},
+        ],
+        "news": [
+            {"url": "https://e.com/n", "title": "新闻N", "description": "新闻描述"},
+        ],
+    },
+    "metadata": {"query": "t"},
+}
+
+
+class YouComWebRetrieverTest(unittest.TestCase):
+
+    def test_unavailable_without_key(self):
+        r = YouComWebRetriever(api_key="")
+        self.assertFalse(r.available)
+        with mock.patch.object(requests, "get") as g:
+            self.assertEqual(r.search("q"), [])
+            g.assert_not_called()
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_maps_web_and_news(self, g):
+        g.return_value = FakeResp(200, SAMPLE)
+        r = YouComWebRetriever(api_key="secret-key")
+        out = r.search("测试", top_k=5)
+
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[0]["index"], 0)
+        self.assertEqual(out[0]["metadata"], {
+            "url": "https://e.com/a", "title": "标题A", "source": "you.com"})
+        self.assertIn("描述A", out[0]["text"])
+        self.assertIn("来源: https://e.com/a", out[0]["text"])
+        self.assertIn("片段B1", out[1]["text"])   # description 缺失回退 snippet
+        self.assertEqual(out[2]["metadata"]["title"], "新闻N")   # news 也纳入
+        # 分数按名次递减
+        self.assertGreater(out[0]["score"], out[2]["score"])
+
+        # 请求头带 X-API-Key 与团队约定 User-Agent；count 为夹取后的值
+        _, kwargs = g.call_args
+        self.assertEqual(kwargs["headers"]["X-API-Key"], "secret-key")
+        self.assertEqual(kwargs["headers"]["User-Agent"], YOUCOM_USER_AGENT)
+        self.assertEqual(kwargs["params"]["query"], "测试")
+        self.assertEqual(kwargs["params"]["count"], 5)
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_top_k_clamped_and_total_truncated(self, g):
+        body = {"results": {
+            "web": [{"url": f"u{i}", "title": f"T{i}"} for i in range(4)],
+            "news": [{"url": "un", "title": "N"}],
+        }}
+        g.return_value = FakeResp(200, body)
+        r = YouComWebRetriever(api_key="k")
+
+        out = r.search("q", top_k=99)                 # 99 → 夹取为 MAX_TOP_K(20)
+        _, kwargs = g.call_args
+        self.assertEqual(kwargs["params"]["count"], 20)
+
+        out = r.search("q", top_k=3)                  # web+news=5 → 截断为 3
+        self.assertEqual(len(out), 3)
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_invalid_top_k_falls_back_to_default(self, g):
+        g.return_value = FakeResp(200, {"results": {"web": []}})
+        r = YouComWebRetriever(api_key="k")
+        r.search("q", top_k="not-an-int")
+        _, kwargs = g.call_args
+        self.assertEqual(kwargs["params"]["count"], 5)
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_non_200_returns_empty_and_no_key_leak(self, g):
+        g.return_value = FakeResp(500, payload={"echo": "secret-key"})
+        r = YouComWebRetriever(api_key="secret-key")
+        out = r.search("q")
+        self.assertEqual(out, [])
+        self.assertNotIn("secret-key", str(out))
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_network_error_returns_empty(self, g):
+        g.side_effect = requests.RequestException("boom")
+        r = YouComWebRetriever(api_key="k")
+        self.assertEqual(r.search("q"), [])
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_bad_json_returns_empty(self, g):
+        g.return_value = FakeResp(200, raise_json=True)
+        r = YouComWebRetriever(api_key="k")
+        self.assertEqual(r.search("q"), [])
+
+    def test_whitespace_key_is_not_available(self):
+        r = YouComWebRetriever(api_key="   ")
+        self.assertFalse(r.available)          # 空白 Key 视为未配置
+        with mock.patch.object(requests, "get") as g:
+            self.assertEqual(r.search("q"), [])
+            g.assert_not_called()
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_non_dict_payloads_return_empty(self, g):
+        # 顶层为 list/str，或 results 为非 dict：不得抛出，统一返回 []
+        for payload in ([1, 2, 3], "oops", {"results": "oops"}, {"results": [1]}):
+            g.return_value = FakeResp(200, payload)
+            r = YouComWebRetriever(api_key="k")
+            self.assertEqual(r.search("q"), [], payload)
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_hostile_shapes_no_crash(self, g):
+        body = {"results": {
+            "web": ["str", 42, None, {"title": None, "url": None,
+                                      "snippets": [None, "有效片段"]}],
+            "news": "not-a-list",
+        }}
+        g.return_value = FakeResp(200, body)
+        r = YouComWebRetriever(api_key="k")
+        out = r.search("q")
+        self.assertEqual(len(out), 1)                 # 非 dict / 非法项被跳过
+        self.assertIn("有效片段", out[0]["text"])
+
+    @mock.patch("core.web_search.youcom_retriever.requests.get")
+    def test_missing_results_node(self, g):
+        g.return_value = FakeResp(200, {"metadata": {}})
+        r = YouComWebRetriever(api_key="k")
+        self.assertEqual(r.search("q"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要 / Summary

新增 `POST /web/search` 端点，作为独立于本地知识库的外部检索器，接入 You.com Search。返回结构与 `/kb/search` 一致；未配置 `YDC_API_KEY` 时返回“未启用”提示，任何异常降级为空，绝不影响本地检索。

Adds a `POST /web/search` endpoint using You.com Search as an external retriever, independent of the local KB. Same response envelope as `/kb/search`; without `YDC_API_KEY` it returns a clear "not enabled" message; all errors degrade to empty and never affect local retrieval.

关联 / Closes #23

## 改动 / Changes

- `core/web_search/youcom_retriever.py`: `YouComWebRetriever`（`requests`），web/news 归一化为 `{index, score, text, metadata}`，top_k 夹取与总数截断。
- `app.py`: `WebSearchQuery` 模型 + `/web/search` 端点。
- `backend/tests/test_youcom_retriever.py`: 11 个单元测试（stdlib unittest）。
- `docker.env` / `README.md` / `README_EN.md`: 配置与用法。

## 测试 / How to test

不需要 Key（单元测试走 mock，不联网 / No key needed, mocked):

    python -m unittest discover -s tests

带 Key / With a real key:

    export YDC_API_KEY=<your key>
    # 启动服务后 / after starting the service:
    curl -s -X POST http://localhost:8028/web/search \
      -H 'Content-Type: application/json' \
      -d '{"query":"latest RAG research","top_k":5}'

未配置 Key 时该端点返回 `{"status":"success","message":"未配置 YDC_API_KEY，联网检索未启用","data":[]}`，其它功能不受影响。

## 说明 / Notes

- Key 仅出现在 `X-API-Key` 请求头；`python-dotenv` 为可选导入（缺失时退化为读真实环境变量，不影响启动）。
- 现网验证 / Live-verified: `GET https://ydc-index.io/v1/search` 真实返回结果。
