### PR TITLE
feat: 阶段B第一步 - 知识图谱数据模型骨架与设计文档

### DIFF
--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -1,0 +1,11 @@
+"""知识图谱模块。"""
+
+from .models import Entity, GraphStore, InMemoryGraphStore, KnowledgeGraph, Relation
+
+__all__ = [
+    "Entity",
+    "GraphStore",
+    "InMemoryGraphStore",
+    "KnowledgeGraph",
+    "Relation",
+]

--- a/core/graph/models.py
+++ b/core/graph/models.py
@@ -1,0 +1,231 @@
+"""知识图谱核心数据模型。"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Entity:
+    """表示知识图谱中的一个节点。"""
+
+    id: str
+    name: str
+    type: str
+    properties: Dict[str, Any] = field(default_factory=dict)
+    source_chunk_ids: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Relation:
+    """表示知识图谱中从起点实体指向终点实体的有向边。"""
+
+    id: str
+    source_entity_id: str
+    target_entity_id: str
+    type: str
+    properties: Dict[str, Any] = field(default_factory=dict)
+    weight: float = 1.0
+
+
+class KnowledgeGraph:
+    """维护实体和关系的内存容器。"""
+
+    def __init__(self) -> None:
+        """初始化内部实体表与关系表。"""
+        self._entities: Dict[str, Entity] = {}
+        self._relations: Dict[str, Relation] = {}
+
+    @property
+    def entities(self) -> Dict[str, Entity]:
+        """返回实体表的浅拷贝，避免外部替换内部容器。"""
+        return dict(self._entities)
+
+    @property
+    def relations(self) -> List[Relation]:
+        """按加入顺序返回关系列表。"""
+        return list(self._relations.values())
+
+    def add_entity(self, entity: Entity) -> str:
+        """加入实体，并合并同名同类型的既有实体。
+
+        Args:
+            entity: 待加入的实体。
+
+        Returns:
+            图谱中实际保存的实体 ID。
+
+        Raises:
+            ValueError: 实体 ID 已存在但名称或类型不一致。
+        """
+        existing_entity = self._entities.get(entity.id)
+        if existing_entity is None:
+            copied_entity = Entity(
+                id=entity.id,
+                name=entity.name,
+                type=entity.type,
+                properties=dict(entity.properties),
+                source_chunk_ids=list(entity.source_chunk_ids),
+            )
+            self._entities[copied_entity.id] = copied_entity
+            return copied_entity.id
+
+        if existing_entity.name != entity.name or existing_entity.type != entity.type:
+            raise ValueError(
+                "实体 ID 已存在，且名称或类型与既有实体不一致: {}".format(entity.id)
+            )
+
+        existing_entity.properties.update(entity.properties)
+        for chunk_id in entity.source_chunk_ids:
+            if chunk_id not in existing_entity.source_chunk_ids:
+                existing_entity.source_chunk_ids.append(chunk_id)
+        return existing_entity.id
+
+    def add_relation(self, relation: Relation) -> str:
+        """加入关系，并确保两个端点实体均存在。
+
+        Args:
+            relation: 待加入的有向关系。
+
+        Returns:
+            图谱中实际保存的关系 ID。
+
+        Raises:
+            ValueError: 起点或终点实体不存在。
+        """
+        missing_entity_ids = [
+            entity_id
+            for entity_id in (relation.source_entity_id, relation.target_entity_id)
+            if entity_id not in self._entities
+        ]
+        if missing_entity_ids:
+            raise ValueError(
+                "关系端点实体不存在: {}".format(", ".join(missing_entity_ids))
+            )
+
+        copied_relation = Relation(
+            id=relation.id,
+            source_entity_id=relation.source_entity_id,
+            target_entity_id=relation.target_entity_id,
+            type=relation.type,
+            properties=dict(relation.properties),
+            weight=relation.weight,
+        )
+        self._relations[copied_relation.id] = copied_relation
+        return copied_relation.id
+
+    def get_entity(self, entity_id: str) -> Optional[Entity]:
+        """按 ID 查询实体。"""
+        return self._entities.get(entity_id)
+
+    def get_relations(self, entity_id: Optional[str] = None) -> List[Relation]:
+        """查询关系，并可按任一端点实体过滤。"""
+        if entity_id is None:
+            return list(self._relations.values())
+
+        return [
+            relation
+            for relation in self._relations.values()
+            if relation.source_entity_id == entity_id
+            or relation.target_entity_id == entity_id
+        ]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """转换为 JSON 友好的字典结构。"""
+        return {
+            "entities": [
+                {
+                    "id": entity.id,
+                    "name": entity.name,
+                    "type": entity.type,
+                    "properties": dict(entity.properties),
+                    "source_chunk_ids": list(entity.source_chunk_ids),
+                }
+                for entity in self._entities.values()
+            ],
+            "relations": [
+                {
+                    "id": relation.id,
+                    "source_entity_id": relation.source_entity_id,
+                    "target_entity_id": relation.target_entity_id,
+                    "type": relation.type,
+                    "properties": dict(relation.properties),
+                    "weight": relation.weight,
+                }
+                for relation in self._relations.values()
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "KnowledgeGraph":
+        """从字典结构恢复知识图谱。
+
+        Args:
+            data: `to_dict` 输出的数据。
+
+        Returns:
+            反序列化后的知识图谱。
+        """
+        graph = cls()
+        for entity_data in data.get("entities", []):
+            graph.add_entity(
+                Entity(
+                    id=entity_data["id"],
+                    name=entity_data["name"],
+                    type=entity_data["type"],
+                    properties=dict(entity_data.get("properties", {})),
+                    source_chunk_ids=list(entity_data.get("source_chunk_ids", [])),
+                )
+            )
+
+        for relation_data in data.get("relations", []):
+            graph.add_relation(
+                Relation(
+                    id=relation_data["id"],
+                    source_entity_id=relation_data["source_entity_id"],
+                    target_entity_id=relation_data["target_entity_id"],
+                    type=relation_data["type"],
+                    properties=dict(relation_data.get("properties", {})),
+                    weight=float(relation_data.get("weight", 1.0)),
+                )
+            )
+        return graph
+
+
+class GraphStore(ABC):
+    """定义知识图谱存储后端接口。"""
+
+    @abstractmethod
+    def save(self, graph: KnowledgeGraph, kb_id: str) -> None:
+        """保存指定知识库的图谱。"""
+
+    @abstractmethod
+    def load(self, kb_id: str) -> Optional[KnowledgeGraph]:
+        """读取指定知识库的图谱，不存在时返回 None。"""
+
+    @abstractmethod
+    def delete(self, kb_id: str) -> bool:
+        """删除指定知识库的图谱，并返回是否删除成功。"""
+
+
+class InMemoryGraphStore(GraphStore):
+    """基于进程内字典的最小图谱存储实现。"""
+
+    def __init__(self) -> None:
+        """初始化内部存储表。"""
+        self._graphs: Dict[str, Dict[str, Any]] = {}
+
+    def save(self, graph: KnowledgeGraph, kb_id: str) -> None:
+        """以序列化快照保存图谱并覆盖旧版本。"""
+        self._graphs[kb_id] = graph.to_dict()
+
+    def load(self, kb_id: str) -> Optional[KnowledgeGraph]:
+        """读取指定图谱的独立快照。"""
+        graph_data = self._graphs.get(kb_id)
+        if graph_data is None:
+            return None
+        return KnowledgeGraph.from_dict(graph_data)
+
+    def delete(self, kb_id: str) -> bool:
+        """删除指定图谱并返回是否删除成功。"""
+        return self._graphs.pop(kb_id, None) is not None

--- a/docs/knowledge-graph-design.md
+++ b/docs/knowledge-graph-design.md
@@ -1,0 +1,178 @@
+# 知识图谱阶段 B 设计文档
+
+## 目标与范围
+
+知识图谱是 EasyRAG 的检索增强层，用于从既有 chunk 中抽取实体与关系，并在向量检索之外提供结构化上下文。阶段 B 的首个增量只交付图谱数据模型、内存存储与单元测试，不改变现有解析、切分、向量入库或检索流程。
+
+本阶段完成后，系统应具备以下能力：
+
+- 以类型化对象表示实体、关系与完整知识图谱。
+- 支持实体去重与合并、关系端点校验、图谱字典序列化与反序列化。
+- 通过 `GraphStore` 抽象隔离后续持久化实现，降低 API 与存储后端的耦合。
+- 为后续图谱检索、子图导出与前端可视化提供稳定的数据基础。
+
+## 数据模型
+
+### Entity
+
+`Entity` 使用 dataclass 表示图谱节点：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | `str` | 实体唯一标识 |
+| `name` | `str` | 实体名称 |
+| `type` | `str` | 实体类型，例如人物、组织、概念 |
+| `properties` | `dict` | 实体扩展属性 |
+| `source_chunk_ids` | `list` | 实体来源 chunk 标识列表 |
+
+同名同类型且使用相同 `id` 的实体重复加入时，`KnowledgeGraph.add_entity` 会合并扩展属性，并按插入顺序合并来源 chunk，不产生重复节点。若相同 `id` 对应不同名称或类型，则拒绝写入，避免破坏实体身份。
+
+### Relation
+
+`Relation` 使用 dataclass 表示有向边：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | `str` | 关系唯一标识 |
+| `source_entity_id` | `str` | 起点实体标识 |
+| `target_entity_id` | `str` | 终点实体标识 |
+| `type` | `str` | 关系类型，例如属于、位于、引用 |
+| `properties` | `dict` | 关系扩展属性 |
+| `weight` | `float` | 关系权重 |
+
+关系加入图谱前会校验起点与终点实体均已存在。缺失任一端点时抛出 `ValueError`，保证图数据始终闭合。
+
+### KnowledgeGraph
+
+`KnowledgeGraph` 是实体与关系的内存容器：
+
+- `add_entity`：加入实体；相同 `id` 且同名同类型时合并属性与来源。
+- `add_relation`：加入关系；两端实体必须存在。
+- `get_entity`：按实体 `id` 查询实体。
+- `get_relations`：按实体 `id` 过滤该实体作为起点或终点的所有关系。
+- `entities` / `relations`：只读属性，返回内部集合的浅拷贝。
+- `to_dict` / `from_dict`：输出和恢复 JSON 友好的字典结构。
+
+字典结构如下：
+
+```json
+{
+  "entities": [
+    {
+      "id": "entity-openai",
+      "name": "OpenAI",
+      "type": "organization",
+      "properties": {"country": "America"},
+      "source_chunk_ids": ["chunk-1"]
+    }
+  ],
+  "relations": [
+    {
+      "id": "relation-1",
+      "source_entity_id": "entity-openai",
+      "target_entity_id": "entity-gpt",
+      "type": "develops",
+      "properties": {},
+      "weight": 1.0
+    }
+  ]
+}
+```
+
+### GraphStore
+
+`GraphStore` 定义存储后端的最小接口：
+
+- `save(graph, kb_id)`：保存知识库对应的图谱，覆盖旧版本。
+- `load(kb_id)`：读取图谱；不存在时返回 `None`。
+- `delete(kb_id)`：删除图谱并返回是否删除成功。
+
+`InMemoryGraphStore` 基于进程内 `dict` 实现该接口，适用于单元测试、临时任务和后续持久化后端的接口验证。它通过序列化快照保存数据，避免保存后原对象继续变更影响已保存版本。
+
+## 与现有流水线的关系
+
+现有流水线保持不变：
+
+```text
+文件解析 → chunker → 向量化 → FAISS 入库/检索 → rerank → 生成回答
+```
+
+知识图谱作为旁路增强层接入：
+
+```text
+chunker 产生的 chunk
+    ├── 原有 FAISS 检索流程
+    └── 实体关系抽取 → KnowledgeGraph → 图谱检索 → 上下文融合
+```
+
+后续融合原则：
+
+- 图谱抽取消费 chunk 及其元数据，不反向修改 chunk。
+- 向量检索仍是默认召回路径，图谱检索提供补充实体、关系与邻域上下文。
+- 图谱服务不可用时，RAG 主流程应可降级为现有行为。
+- 图谱构建、检索与可视化均按知识库 `kb_id` 隔离。
+
+## REST API 契约草案
+
+以下端点仅为阶段 B 设计草案，本阶段不实现。后续实现必须与现有知识库 API 的错误格式、鉴权方式与路径规范保持一致。
+
+### 获取完整图谱
+
+```http
+GET /kb/{kb_id}/graph
+```
+
+成功返回 `KnowledgeGraph.to_dict()` 对应结构；图谱不存在返回 `404`。生产环境中应支持 `nodes` / `edges` 分页或按查询深度裁剪，避免大图一次性返回。
+
+### 查询实体列表
+
+```http
+GET /kb/{kb_id}/graph/entities?type=&name=&limit=&offset=
+```
+
+返回实体数组与分页信息。`name` 建议使用精确匹配，模糊搜索可由后续搜索参数扩展。
+
+### 查询实体详情与邻域
+
+```http
+GET /kb/{kb_id}/graph/entities/{entity_id}
+GET /kb/{kb_id}/graph/entities/{entity_id}/relations
+```
+
+详情接口返回实体及其一度关系摘要；关系接口支持 `direction=in|out|both` 与 `limit` 参数。
+
+### 查询关系列表
+
+```http
+GET /kb/{kb_id}/graph/relations?entity_id=&type=&limit=&offset=
+```
+
+`entity_id` 存在时返回该实体关联的关系；不传时返回分页关系列表。
+
+### 触发图谱构建
+
+```http
+POST /kb/{kb_id}/graph/extract
+```
+
+请求体可指定 chunk 范围、抽取模型与实体类型白名单。构建可能是长任务，建议返回任务标识并提供任务状态查询接口；实现细节在 step2 设计中确定。
+
+### 删除图谱
+
+```http
+DELETE /kb/{kb_id}/graph
+```
+
+删除该知识库的图谱数据，不影响已入库 chunk 与向量索引。图谱不存在时返回 `404` 或幂等 `204`，需与现有删除语义保持一致。
+
+## 分阶段增量计划
+
+| 阶段 | 内容 | 交付边界 |
+| --- | --- | --- |
+| step1 | 数据模型骨架 | `Entity`、`Relation`、`KnowledgeGraph`、`GraphStore`、`InMemoryGraphStore` 与单元测试 |
+| step2 | LLM 实体关系抽取器 | 从 chunk 抽取实体和关系，输出可校验的 `KnowledgeGraph`，处理重试与模型输出约束 |
+| step3 | 持久化存储后端 | 实现生产可用的 `GraphStore`，支持版本、事务、迁移与按知识库隔离 |
+| step4 | API 端点 | 实现图谱查询、构建任务与删除接口，完成鉴权、分页和错误处理 |
+| step5 | 前端可视化 | 提供图谱浏览、搜索、节点详情和邻域展开，支持大数据量渐进加载 |
+
+每个阶段保持独立可回滚：新增能力通过显式配置启用，不改变默认 RAG 检索结果；跨阶段接口变更必须通过单元测试与 API 兼容性评审。

--- a/tests/test_graph_models.py
+++ b/tests/test_graph_models.py
@@ -1,0 +1,169 @@
+"""知识图谱数据模型单元测试。"""
+
+import json
+
+import pytest
+
+from core.graph import Entity, InMemoryGraphStore, KnowledgeGraph, Relation
+
+
+def make_graph() -> KnowledgeGraph:
+    """构造包含两个实体和一条关系的测试图谱。"""
+    graph = KnowledgeGraph()
+    graph.add_entity(
+        Entity(
+            id="entity-openai",
+            name="OpenAI",
+            type="organization",
+            properties={"country": "America"},
+            source_chunk_ids=["chunk-1"],
+        )
+    )
+    graph.add_entity(
+        Entity(
+            id="entity-gpt",
+            name="GPT",
+            type="model",
+            properties={"version": 4},
+            source_chunk_ids=["chunk-1"],
+        )
+    )
+    graph.add_relation(
+        Relation(
+            id="relation-develops",
+            source_entity_id="entity-openai",
+            target_entity_id="entity-gpt",
+            type="develops",
+            properties={"since": 2018},
+            weight=0.8,
+        )
+    )
+    return graph
+
+
+def test_add_and_get_entity() -> None:
+    """实体加入图谱后可按 ID 查询，并保持传入数据一致。"""
+    graph = KnowledgeGraph()
+    entity = Entity(
+        id="entity-easyrag",
+        name="EasyRAG",
+        type="project",
+        properties={"language": "Python"},
+        source_chunk_ids=["chunk-1", "chunk-2"],
+    )
+
+    assert graph.add_entity(entity) == "entity-easyrag"
+    assert graph.get_entity("entity-easyrag") == entity
+    assert graph.entities == {"entity-easyrag": entity}
+    assert graph.get_entity("missing") is None
+
+
+def test_merge_entities_with_same_id_name_and_type() -> None:
+    """重复实体按 ID 去重，并合并属性与来源 chunk。"""
+    graph = KnowledgeGraph()
+    first = Entity(
+        id="entity-openai",
+        name="OpenAI",
+        type="organization",
+        properties={"country": "America", "city": "San Francisco"},
+        source_chunk_ids=["chunk-1", "chunk-2"],
+    )
+    second = Entity(
+        id="entity-openai",
+        name="OpenAI",
+        type="organization",
+        properties={"city": "San Francisco", "founded": 2015},
+        source_chunk_ids=["chunk-2", "chunk-3"],
+    )
+
+    graph.add_entity(first)
+    graph.add_entity(second)
+
+    merged_entity = graph.get_entity("entity-openai")
+    assert merged_entity is not None
+    assert merged_entity.properties == {
+        "country": "America",
+        "city": "San Francisco",
+        "founded": 2015,
+    }
+    assert merged_entity.source_chunk_ids == ["chunk-1", "chunk-2", "chunk-3"]
+    assert len(graph.entities) == 1
+
+
+def test_add_relation_requires_existing_entities() -> None:
+    """关系任一端点不存在时必须拒绝写入。"""
+    graph = KnowledgeGraph()
+    graph.add_entity(
+        Entity(id="entity-openai", name="OpenAI", type="organization")
+    )
+    relation = Relation(
+        id="relation-invalid",
+        source_entity_id="entity-openai",
+        target_entity_id="entity-missing",
+        type="develops",
+    )
+
+    with pytest.raises(ValueError) as error:
+        graph.add_relation(relation)
+
+    assert "entity-missing" in str(error.value)
+    assert graph.relations == []
+
+
+def test_get_relations_filtered_by_entity() -> None:
+    """实体过滤应同时覆盖作为起点和终点的关系。"""
+    graph = make_graph()
+    graph.add_entity(
+        Entity(id="entity-user", name="User", type="role")
+    )
+    graph.add_relation(
+        Relation(
+            id="relation-uses",
+            source_entity_id="entity-user",
+            target_entity_id="entity-gpt",
+            type="uses",
+        )
+    )
+
+    assert [relation.id for relation in graph.get_relations("entity-gpt")] == [
+        "relation-develops",
+        "relation-uses",
+    ]
+    assert [relation.id for relation in graph.get_relations("entity-user")] == [
+        "relation-uses",
+    ]
+    assert len(graph.get_relations()) == 2
+
+
+def test_json_round_trip() -> None:
+    """图谱字典经 JSON 文本往返后保持数据一致。"""
+    graph = make_graph()
+    graph_data = json.loads(json.dumps(graph.to_dict(), ensure_ascii=False))
+
+    restored_graph = KnowledgeGraph.from_dict(graph_data)
+
+    assert restored_graph.to_dict() == graph.to_dict()
+    assert restored_graph.entities == graph.entities
+    assert restored_graph.relations == graph.relations
+
+
+def test_in_memory_graph_store_save_load_and_delete() -> None:
+    """内存存储支持保存、读取、覆盖与删除。"""
+    store = InMemoryGraphStore()
+    graph = make_graph()
+
+    assert store.load("kb-1") is None
+    store.save(graph, "kb-1")
+    loaded_graph = store.load("kb-1")
+
+    assert loaded_graph is not None
+    assert loaded_graph.to_dict() == graph.to_dict()
+
+    graph.add_entity(
+        Entity(id="entity-user", name="User", type="role")
+    )
+    assert "entity-user" not in store.load("kb-1").entities
+
+    assert store.delete("kb-1") is True
+    assert store.load("kb-1") is None
+    assert store.delete("kb-1") is False


### PR DESCRIPTION
## 概要
迭代阶段 **B（知识图谱）** 第一个可控增量：交付图谱数据模型骨架（`core/graph/`）、中文设计文档与单元测试。**不改动任何现有文件、不接入运行时、零新增依赖**，默认 RAG 行为完全不变。

## 变更（4 文件，+589 行，commit c0130fd）
- `docs/knowledge-graph-design.md`（新增）：目标与范围、数据模型、与现有 chunker→FAISS 流水线的旁路增强关系、REST API 契约草案（/kb/{kb_id}/graph/*）、step1–step5 增量计划
- `core/graph/models.py`（新增）：`Entity`/`Relation` dataclass、`KnowledgeGraph` 容器（实体按 ID 去重合并、关系端点校验 ValueError、to_dict/from_dict JSON 往返）、`GraphStore` 抽象接口、`InMemoryGraphStore`（快照式内存实现）；纯标准库，Python 3.8+ 兼容，中文 docstring + 完整类型注解
- `core/graph/__init__.py`（新增）：模块导出
- `tests/test_graph_models.py`（新增）：6 个纯单元测试——实体增查、同名同类型合并、关系端点校验、实体过滤关系、JSON 往返、内存存储 save/load/delete 与快照隔离

## 验证证据（基线对比法，均通过）
| 闸门 | 命令 | 基线（origin/main） | 本分支 | 结果 |
|------|------|------|------|------|
| Lint(py) | `flake8 . --count --select=E9,F63,F7,F82` | 10 个预存错误（app.py×1, chunker×3, file_read×6） | 同样 10 个，逐条一致，零新增 | ✅ |
| Lint(py新增) | `flake8 core/graph/__init__.py core/graph/models.py tests/test_graph_models.py --count` | — | 0 错误 | ✅ |
| Test | `python3 -m pytest tests/ -q` | 11 passed | **17 passed**（11 既有 + 6 新增） | ✅ |
| Lint(fe) | `npm run lint` | exit 0 | exit 0 | ✅ |
| Build | `npm run build` | exit 0（7 modules → dist/frontend/） | exit 0 | ✅ |

说明：全仓 flake8 退出码为 1 系 main 基线即存在的 10 个预存错误（与本增量无关，清单见上表基线列）；本增量采用「与基线逐条对比 + 新增文件零错误」判定，未触碰任何预存问题文件。无前端改动，故本增量不涉及 Playwright 冒烟（阶段C 套件在 PR #26，待其合入后后续增量统一启用）。

执行方式：Codex CLI（gpt-5.3-codex，-s danger-full-access，因本容器禁用非特权 userns 导致 bwrap 沙箱不可用）按质量闸门流程执行代码编写；闸门由编排器独立复跑确认。

## 后续（下一增量候选）
- 阶段B step2：LLM 实体关系抽取器（消费 chunk → 输出 KnowledgeGraph，含输出校验与重试）
- 或 PR #26（阶段C+D）review 合入后：为后续所有前端增量启用强制冒烟闸门