### PR TITLE
feat(draft): 阶段B step2 - LLM实体关系抽取器（schema校验+重试）

### DIFF
--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -1,11 +1,14 @@
 """知识图谱模块。"""
 
+from .extractor import GraphExtractionError, LLMEntityRelationExtractor
 from .models import Entity, GraphStore, InMemoryGraphStore, KnowledgeGraph, Relation
 
 __all__ = [
     "Entity",
+    "GraphExtractionError",
     "GraphStore",
     "InMemoryGraphStore",
     "KnowledgeGraph",
+    "LLMEntityRelationExtractor",
     "Relation",
 ]

--- a/core/graph/extractor.py
+++ b/core/graph/extractor.py
@@ -1,0 +1,462 @@
+"""基于 LLM 的知识图谱实体关系抽取器。"""
+
+import json
+import logging
+import re
+from hashlib import sha1
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+from core.graph.models import Entity, KnowledgeGraph, Relation
+
+logger = logging.getLogger(__name__)
+
+
+class GraphExtractionError(Exception):
+    """表示图谱抽取失败，或模型输出重试后仍不可用。"""
+
+
+class LLMEntityRelationExtractor:
+    """调用 LLM 从文本 chunk 中抽取实体与关系。"""
+
+    def __init__(
+        self,
+        llm_client: Any = None,
+        max_retries: int = 2,
+        temperature: float = 0.0,
+        max_entities_per_chunk: int = 50,
+        max_relations_per_chunk: int = 80,
+        entity_types: Optional[Iterable[str]] = None,
+        max_chunk_chars: int = 6000,
+    ) -> None:
+        """初始化抽取配置，默认模型客户端在首次调用时惰性创建。
+
+        Args:
+            llm_client: 兼容 ``generate_response`` 的模型客户端。
+            max_retries: JSON 结构无效时的最大额外调用次数。
+            temperature: 抽取温度。
+            max_entities_per_chunk: 单个 chunk 允许保存的最大实体数。
+            max_relations_per_chunk: 单个 chunk 允许保存的最大关系数。
+            entity_types: 实体类型白名单；为 ``None`` 时不过滤。
+            max_chunk_chars: 输入文本最大字符数，超出部分先截断。
+        """
+        self._llm_client = llm_client
+        self._max_retries = max_retries
+        self._temperature = temperature
+        self._max_entities_per_chunk = max_entities_per_chunk
+        self._max_relations_per_chunk = max_relations_per_chunk
+        self._entity_types = set(entity_types) if entity_types is not None else None
+        self._max_chunk_chars = max_chunk_chars
+        self.last_run_stats: Dict[str, Any] = {}
+
+    @staticmethod
+    def _entity_id(name: str, entity_type: str) -> str:
+        """生成确定性实体 ID。"""
+        digest = sha1("{}|{}".format(name, entity_type).encode("utf-8")).hexdigest()[:12]
+        return "entity-" + digest
+
+    @staticmethod
+    def _relation_id(source: str, relation_type: str, target: str) -> str:
+        """生成确定性关系 ID。"""
+        key = "{}|{}|{}".format(source, relation_type, target)
+        return "relation-" + sha1(key.encode("utf-8")).hexdigest()[:12]
+
+    @staticmethod
+    def _deep_merge(target: Dict[str, Any], source: Dict[str, Any]) -> None:
+        """递归合并属性字典，保持目标字典可变。"""
+        for key, value in source.items():
+            if isinstance(value, dict) and isinstance(target.get(key), dict):
+                LLMEntityRelationExtractor._deep_merge(target[key], value)
+            else:
+                target[key] = value
+
+    @staticmethod
+    def _extract_balanced_json(text: str) -> Optional[str]:
+        """截取文本中首个语法上平衡的 JSON 对象片段。"""
+        start = text.find("{")
+        if start < 0:
+            return None
+
+        depth = 0
+        in_string = False
+        escaped = False
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                escaped, in_string = LLMEntityRelationExtractor._scan_json_string(
+                    char, escaped, in_string
+                )
+                continue
+
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : index + 1]
+        return None
+
+    @staticmethod
+    def _scan_json_string(char: str, escaped: bool, in_string: bool) -> Tuple[bool, bool]:
+        """更新 JSON 字符串扫描状态。"""
+        if escaped:
+            return False, in_string
+        if char == "\\":
+            return True, in_string
+        if char == '"':
+            return escaped, False
+        return escaped, in_string
+
+    @classmethod
+    def _load_json_object(cls, response: str) -> Optional[Dict[str, Any]]:
+        """容错解析模型输出中的 JSON 对象。"""
+        cleaned = response.strip()
+        fence_pattern = re.compile(r"^```(?:json)?\s*(.*?)\s*```$", re.DOTALL | re.IGNORECASE)
+        fence_match = fence_pattern.match(cleaned)
+        if fence_match:
+            cleaned = fence_match.group(1).strip()
+        try:
+            candidate = cleaned if cleaned.startswith("{") else cls._extract_balanced_json(cleaned)
+            if candidate is None:
+                return None
+            data = json.loads(candidate)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _build_prompt(self, text: str, truncated: bool, previous_error: Optional[str]) -> str:
+        """构造中文实体关系抽取提示词。"""
+        prompt = """你是一个严谨的知识图谱信息抽取器。请从给定文本中抽取实体和关系。
+
+要求：
+1. 只输出一个 JSON 对象，不加任何解释，不使用 Markdown 代码块。
+2. 实体名和实体类型可使用中文或英文；关系的 source 和 target 必须严格使用实体列表中的实体名。
+3. properties 与 weight 可省略；weight 必须是数字。
+4. 若无法抽取实体或关系，输出 {"entities": [], "relations": []}。
+
+输出 JSON schema：
+{"entities": [{"name": "...", "type": "...", "properties": {}}],
+ "relations": [{"source": "...", "target": "...", "type": "...", "weight": 0.9, "properties": {}}]}
+"""
+        if truncated:
+            prompt += "\n注意：以下文本超过输入上限，已截断。\n"
+        prompt += "\n待抽取文本：\n" + text
+        if previous_error:
+            prompt += "\n\n上一轮输出无效，错误原因：{}\n请修正后只输出一个合法 JSON 对象。".format(previous_error)
+        return prompt
+
+    def _get_llm_client(self) -> Any:
+        """返回注入客户端，或惰性初始化 OpenAI 兼容客户端。"""
+        if self._llm_client is not None:
+            return self._llm_client
+        try:
+            from core.llm.openai_llm_model import get_openai_model
+
+            self._llm_client = get_openai_model()
+            return self._llm_client
+        except Exception as error:
+            raise GraphExtractionError("初始化 OpenAI 兼容模型失败: {}".format(error)) from error
+
+    @staticmethod
+    def _normalize_weight(raw_weight: Any, relation_id: str, chunk_id: str) -> float:
+        """校验关系权重，非法值回退并越界值钳制。"""
+        if isinstance(raw_weight, bool):
+            logger.warning("chunk=%s 关系 %s weight 非法，回退为 1.0", chunk_id, relation_id)
+            return 1.0
+        try:
+            weight = float(raw_weight)
+        except (TypeError, ValueError):
+            logger.warning("chunk=%s 关系 %s weight 非法，回退为 1.0", chunk_id, relation_id)
+            return 1.0
+        if weight < 0.0:
+            logger.warning("chunk=%s 关系 %s weight 低于下限，钳制为 0.0", chunk_id, relation_id)
+            return 0.0
+        if weight > 1.0:
+            logger.warning("chunk=%s 关系 %s weight 高于上限，钳制为 1.0", chunk_id, relation_id)
+            return 1.0
+        return weight
+
+    def _parse_and_validate(
+        self, output: str, chunk_id: str
+    ) -> Tuple[Optional[KnowledgeGraph], Optional[str]]:
+        """解析并校验模型输出，返回图谱与结构错误原因。"""
+        data = self._load_json_object(output)
+        if data is None:
+            return None, "JSON 解析失败或不存在平衡 JSON 对象"
+        if "entities" not in data or "relations" not in data:
+            return None, "顶层结构不是包含 entities 和 relations 的 JSON 对象"
+        if not isinstance(data["entities"], list) or not isinstance(data["relations"], list):
+            return None, "entities 或 relations 不是数组"
+
+        entities = self._parse_entities(data["entities"], chunk_id)
+        if len(entities) > self._max_entities_per_chunk:
+            logger.warning(
+                "chunk=%s 去重后实体数 %s 超过上限 %s，已截断",
+                chunk_id,
+                len(entities),
+                self._max_entities_per_chunk,
+            )
+            entities = entities[: self._max_entities_per_chunk]
+
+        graph = KnowledgeGraph()
+        name_to_id: Dict[str, str] = {}
+        for entity in entities:
+            graph.add_entity(
+                Entity(
+                    id=entity.id,
+                    name=entity.name,
+                    type=entity.type,
+                    properties=dict(entity.properties),
+                    source_chunk_ids=[chunk_id],
+                )
+            )
+            name_to_id[entity.name] = entity.id
+
+        self._parse_relations(data["relations"], graph, name_to_id, chunk_id)
+        return graph, None
+
+    def _parse_entities(self, raw_entities: List[Any], chunk_id: str) -> List[Entity]:
+        """解析、过滤并合并实体输出。"""
+        entity_map: Dict[Tuple[str, str], Entity] = {}
+        for raw_entity in raw_entities:
+            entity_fields = self._parse_entity_fields(raw_entity, chunk_id)
+            if entity_fields is None:
+                continue
+            name, entity_type, properties = entity_fields
+            key = (name, entity_type)
+            entity = entity_map.get(key)
+            if entity is None:
+                entity_map[key] = Entity(
+                    id=self._entity_id(name, entity_type),
+                    name=name,
+                    type=entity_type,
+                    properties=properties,
+                )
+            else:
+                self._deep_merge(entity.properties, properties)
+        return list(entity_map.values())
+
+    def _parse_entity_fields(
+        self, raw_entity: Any, chunk_id: str
+    ) -> Optional[Tuple[str, str, Dict[str, Any]]]:
+        """提取并校验单个实体字段。"""
+        if not isinstance(raw_entity, dict):
+            logger.warning("chunk=%s 忽略非对象实体输出", chunk_id)
+            return None
+        name = raw_entity.get("name")
+        entity_type = raw_entity.get("type")
+        if not isinstance(name, str) or not name.strip():
+            logger.warning("chunk=%s 忽略缺少有效 name 的实体", chunk_id)
+            return None
+        if not isinstance(entity_type, str) or not entity_type.strip():
+            logger.warning("chunk=%s 忽略缺少有效 type 的实体", chunk_id)
+            return None
+
+        name = name.strip()
+        entity_type = entity_type.strip()
+        if self._entity_types is not None and entity_type not in self._entity_types:
+            logger.warning("chunk=%s 过滤白名单外实体类型: %s", chunk_id, entity_type)
+            return None
+        properties = raw_entity.get("properties", {})
+        if not isinstance(properties, dict):
+            logger.warning("chunk=%s 忽略实体 %s 的非对象 properties", chunk_id, name)
+            properties = {}
+        return name, entity_type, dict(properties)
+
+    def _parse_relations(
+        self,
+        raw_relations: List[Any],
+        graph: KnowledgeGraph,
+        name_to_id: Dict[str, str],
+        chunk_id: str,
+    ) -> None:
+        """解析关系输出并写入图谱。"""
+        relation_ids: Set[str] = set()
+        saved_relations = 0
+        raw_relations = list(raw_relations)
+        if len(raw_relations) > self._max_relations_per_chunk:
+            logger.warning(
+                "chunk=%s 关系数 %s 超过上限 %s，将截断",
+                chunk_id,
+                len(raw_relations),
+                self._max_relations_per_chunk,
+            )
+        for raw_relation in raw_relations:
+            if saved_relations >= self._max_relations_per_chunk:
+                logger.warning(
+                    "chunk=%s 关系数超过上限 %s，已截断",
+                    chunk_id,
+                    self._max_relations_per_chunk,
+                )
+                break
+            if not isinstance(raw_relation, dict):
+                logger.warning("chunk=%s 忽略非对象关系输出", chunk_id)
+                continue
+            source = raw_relation.get("source")
+            target = raw_relation.get("target")
+            relation_type = raw_relation.get("type")
+            if not all(isinstance(value, str) for value in (source, target, relation_type)):
+                logger.warning("chunk=%s 忽略端点或类型不是字符串的关系", chunk_id)
+                continue
+
+            source = source.strip()
+            target = target.strip()
+            relation_type = relation_type.strip()
+            if not relation_type:
+                logger.warning("chunk=%s 忽略类型为空的关系", chunk_id)
+                continue
+            if source not in name_to_id or target not in name_to_id:
+                logger.warning(
+                    "chunk=%s 丢弃端点不存在的关系: %s -> %s",
+                    chunk_id,
+                    source,
+                    target,
+                )
+                continue
+
+            relation_id = self._relation_id(source, relation_type, target)
+            if relation_id in relation_ids:
+                logger.warning("chunk=%s 忽略重复关系: %s", chunk_id, relation_id)
+                continue
+            relation_ids.add(relation_id)
+
+            properties = raw_relation.get("properties", {})
+            if not isinstance(properties, dict):
+                logger.warning("chunk=%s 忽略关系 %s 的非对象 properties", chunk_id, relation_id)
+                properties = {}
+            graph.add_relation(
+                Relation(
+                    id=relation_id,
+                    source_entity_id=name_to_id[source],
+                    target_entity_id=name_to_id[target],
+                    type=relation_type,
+                    properties=dict(properties),
+                    weight=self._normalize_weight(
+                        raw_relation.get("weight", 1.0), relation_id, chunk_id
+                    ),
+                )
+            )
+            saved_relations += 1
+
+    def extract_from_chunk(self, text: str, chunk_id: str) -> KnowledgeGraph:
+        """从单个文本 chunk 抽取知识图谱。
+
+        Args:
+            text: chunk 文本，超出上限时先截断。
+            chunk_id: chunk 标识，写入实体来源。
+
+        Returns:
+            抽取得到的独立知识图谱。
+
+        Raises:
+            GraphExtractionError: 模型客户端不可用、调用失败或结构错误重试耗尽。
+        """
+        if not isinstance(text, str) or not isinstance(chunk_id, str):
+            raise GraphExtractionError("text 与 chunk_id 必须是字符串")
+
+        truncated = len(text) > self._max_chunk_chars
+        source_text = text[: self._max_chunk_chars] if truncated else text
+        previous_error: Optional[str] = None
+        last_error = "未知错误"
+
+        try:
+            llm_client = self._get_llm_client()
+            for attempt in range(self._max_retries + 1):
+                prompt = self._build_prompt(source_text, truncated, previous_error)
+                output = llm_client.generate_response(
+                    prompt, temperature=self._temperature, max_length=4096
+                )
+                graph, current_error = self._parse_and_validate(output, chunk_id)
+                if current_error is None:
+                    return graph
+
+                previous_error = current_error
+                last_error = current_error
+                logger.warning(
+                    "chunk=%s 第 %s 次抽取输出无效: %s", chunk_id, attempt + 1, current_error
+                )
+        except GraphExtractionError:
+            raise
+        except Exception as error:
+            raise GraphExtractionError("图谱抽取调用失败: {}".format(error)) from error
+
+        raise GraphExtractionError("chunk={} 抽取失败: {}".format(chunk_id, last_error))
+
+    def extract_from_chunks(
+        self, chunks: List[Tuple[str, str]], strict: bool = False
+    ) -> KnowledgeGraph:
+        """逐个抽取 chunk，并把结果合并进同一个知识图谱。
+
+        Args:
+            chunks: ``(chunk_id, text)`` 元组列表。
+            strict: 为 ``True`` 时任一 chunk 失败立即抛出异常。
+
+        Returns:
+            合并后的知识图谱；批量统计记录在 ``last_run_stats``。
+
+        Raises:
+            GraphExtractionError: ``strict=True`` 且任一 chunk 抽取失败。
+        """
+        graph = KnowledgeGraph()
+        successful_chunks = 0
+        failed_chunks: List[str] = []
+        chunk_errors: Dict[str, str] = {}
+        total_entities = 0
+        total_relations = 0
+
+        for chunk_id, text in chunks:
+            try:
+                chunk_graph = self.extract_from_chunk(text, chunk_id)
+            except GraphExtractionError as error:
+                logger.warning("chunk=%s 抽取失败，strict=%s: %s", chunk_id, strict, error)
+                failed_chunks.append(chunk_id)
+                chunk_errors[chunk_id] = str(error)
+                if strict:
+                    self._record_batch_stats(
+                        len(chunks),
+                        successful_chunks,
+                        failed_chunks,
+                        chunk_errors,
+                        total_entities,
+                        total_relations,
+                    )
+                    raise
+                continue
+
+            for entity in chunk_graph.entities.values():
+                graph.add_entity(entity)
+            for relation in chunk_graph.relations:
+                graph.add_relation(relation)
+            successful_chunks += 1
+            total_entities += len(chunk_graph.entities)
+            total_relations += len(chunk_graph.relations)
+
+        self._record_batch_stats(
+            len(chunks),
+            successful_chunks,
+            failed_chunks,
+            chunk_errors,
+            total_entities,
+            total_relations,
+        )
+        return graph
+
+    def _record_batch_stats(
+        self,
+        total_chunks: int,
+        successful_chunks: int,
+        failed_chunks: List[str],
+        chunk_errors: Dict[str, str],
+        total_entities: int,
+        total_relations: int,
+    ) -> None:
+        """记录批量抽取统计。"""
+        self.last_run_stats = {
+            "total_chunks": total_chunks,
+            "succeeded_chunks": successful_chunks,
+            "failed_chunks": failed_chunks,
+            "chunk_errors": chunk_errors,
+            "total_entities": total_entities,
+            "total_relations": total_relations,
+        }

--- a/docs/knowledge-graph-design.md
+++ b/docs/knowledge-graph-design.md
@@ -165,6 +165,44 @@ DELETE /kb/{kb_id}/graph
 
 删除该知识库的图谱数据，不影响已入库 chunk 与向量索引。图谱不存在时返回 `404` 或幂等 `204`，需与现有删除语义保持一致。
 
+## step2 抽取输出契约
+
+`LLMEntityRelationExtractor` 以 chunk 为单位调用 LLM，并要求模型输出如下 JSON 对象：
+
+```json
+{
+  "entities": [
+    {"name": "OpenAI", "type": "组织", "properties": {}}
+  ],
+  "relations": [
+    {
+      "source": "OpenAI",
+      "target": "GPT",
+      "type": "研发",
+      "weight": 0.9,
+      "properties": {}
+    }
+  ]
+}
+```
+
+校验规则：
+
+- `entities` 与 `relations` 必须为数组；空数组合法，`properties` 与 `weight` 可省略。
+- 实体 `name` 与 `type` 必须是非空字符串；同一 chunk 内相同 `(name, type)` 合并并深度合并属性，超限截断。
+- 配置实体类型白名单时，过滤白名单外实体，并级联丢弃任一端点已被过滤的关系。
+- 关系 `source` 与 `target` 必须精确匹配本 chunk 保留实体的 `name`；不匹配的关系直接丢弃，不触发重试。
+- 关系 `type` 必须为非空字符串；`weight` 默认 `1.0`，非法值回退 `1.0`，越界值钳制到 `[0.0, 1.0]`，超限截断并按确定性 ID 去重。
+- 输入文本超过 `max_chunk_chars` 时先截断，再构造提示词。
+
+解析与重试：
+
+- 解析时移除 Markdown 围栏，并截取首个平衡的 JSON 对象。
+- 仅 JSON 解析失败、顶层缺少必需字段或数组类型不符会重试；每次重试会把上一轮错误写入提示词。额外调用最多 `max_retries` 次，耗尽后抛出 `GraphExtractionError`。
+- 端点缺失、白名单过滤、数量截断、权重修正等属于语义修正或丢弃，不消耗重试。
+
+批量抽取 `extract_from_chunks` 逐 chunk 调用单 chunk 逻辑，并复用 `KnowledgeGraph` 的同名同类型实体合并语义聚合 `source_chunk_ids` 与属性。任一 chunk 失败时默认记录 warning 并继续，失败信息与计数保存在 `last_run_stats`；`strict=True` 时立即抛出 `GraphExtractionError`。
+
 ## 分阶段增量计划
 
 | 阶段 | 内容 | 交付边界 |

--- a/tests/test_graph_extractor.py
+++ b/tests/test_graph_extractor.py
@@ -1,0 +1,247 @@
+"""知识图谱 LLM 抽取器离线单元测试。"""
+
+import hashlib
+import json
+import sys
+
+import pytest
+
+from core.graph import GraphExtractionError, LLMEntityRelationExtractor
+
+
+class FakeLLM:
+    """按调用顺序返回预设响应的离线 LLM。"""
+
+    def __init__(self, responses):
+        """保存预设响应并初始化调用记录。"""
+        self.responses = list(responses)
+        self.calls = []
+
+    def generate_response(self, query, temperature=None, max_length=None):
+        """记录请求参数并返回下一条预设响应。"""
+        self.calls.append(
+            {
+                "query": query,
+                "temperature": temperature,
+                "max_length": max_length,
+            }
+        )
+        if not self.responses:
+            raise AssertionError("FakeLLM 响应已耗尽")
+        return self.responses.pop(0)
+
+
+def make_extractor(responses, **kwargs):
+    """构造使用 FakeLLM 的抽取器。"""
+    llm = FakeLLM(responses)
+    return LLMEntityRelationExtractor(llm_client=llm, **kwargs), llm
+
+
+def entity_id(name, entity_type):
+    """计算测试期望的实体 ID。"""
+    digest = hashlib.sha1("{}|{}".format(name, entity_type).encode("utf-8")).hexdigest()[:12]
+    return "entity-" + digest
+
+
+def relation_id(source, relation_type, target):
+    """计算测试期望的关系 ID。"""
+    digest = hashlib.sha1("{}|{}|{}".format(source, relation_type, target).encode("utf-8")).hexdigest()[:12]
+    return "relation-" + digest
+
+
+def test_normal_json_builds_deterministic_graph():
+    """正常 JSON 输出可转换为确定性图谱。"""
+    payload = {
+        "entities": [
+            {"name": "OpenAI", "type": "组织", "properties": {"country": "America"}},
+            {"name": "OpenAI", "type": "组织", "properties": {"model": "GPT"}},
+            {"name": "GPT", "type": "技术"},
+        ],
+        "relations": [
+            {"source": "OpenAI", "target": "GPT", "type": "研发", "weight": 0.9}
+        ],
+    }
+    extractor, llm = make_extractor([json.dumps(payload)])
+    graph = extractor.extract_from_chunk("OpenAI 研发 GPT", "chunk-1")
+
+    openai_id = entity_id("OpenAI", "组织")
+    gpt_id = entity_id("GPT", "技术")
+    assert set(graph.entities) == {openai_id, gpt_id}
+    assert graph.entities[openai_id].properties == {"country": "America", "model": "GPT"}
+    assert graph.entities[openai_id].source_chunk_ids == ["chunk-1"]
+    relation = graph.relations[0]
+    assert relation.id == relation_id("OpenAI", "研发", "GPT")
+    assert relation.source_entity_id == openai_id
+    assert relation.target_entity_id == gpt_id
+    assert relation.weight == pytest.approx(0.9)
+    assert llm.calls[0]["temperature"] == 0.0
+
+
+def test_json_with_markdown_fence_and_noise_is_extracted():
+    """围栏和前后噪声不影响平衡 JSON 对象截取。"""
+    response = '前置噪声 ```json\n{"entities": [{"name": "张三", "type": "人物"}], "relations": []}\n``` 后置噪声'
+    extractor, _ = make_extractor([response])
+    graph = extractor.extract_from_chunk("张三是一名工程师。", "chunk-1")
+    assert list(graph.entities) == [entity_id("张三", "人物")]
+
+
+def test_invalid_json_then_valid_retries_successfully():
+    """顶层 JSON 解析失败会携带错误原因重试。"""
+    valid = json.dumps({"entities": [], "relations": []})
+    extractor, llm = make_extractor(["不是 JSON", valid], max_retries=2)
+    graph = extractor.extract_from_chunk("文本", "chunk-1")
+
+    assert graph.to_dict() == {"entities": [], "relations": []}
+    assert len(llm.calls) == 2
+    assert "JSON 解析失败" in llm.calls[1]["query"]
+    assert "上一轮输出无效" in llm.calls[1]["query"]
+
+
+def test_invalid_json_exhausts_retries():
+    """连续结构错误按 1 加重试次数调用后失败。"""
+    extractor, llm = make_extractor(["bad", "bad", "bad"], max_retries=2)
+    with pytest.raises(GraphExtractionError, match="JSON 解析失败"):
+        extractor.extract_from_chunk("文本", "chunk-1")
+    assert len(llm.calls) == 3
+
+
+def test_unknown_relation_endpoint_is_dropped_without_retry():
+    """关系端点不匹配属于语义修正，不触发重试。"""
+    payload = {
+        "entities": [{"name": "OpenAI", "type": "组织"}],
+        "relations": [
+            {"source": "OpenAI", "target": "不存在", "type": "研发"},
+            {"source": "OpenAI", "target": "OpenAI", "type": "自指"},
+        ],
+    }
+    extractor, llm = make_extractor([json.dumps(payload)], max_retries=2)
+    graph = extractor.extract_from_chunk("文本", "chunk-1")
+    assert len(graph.relations) == 1
+    assert graph.relations[0].type == "自指"
+    assert len(llm.calls) == 1
+
+
+def test_entity_type_whitelist_cascades_relations():
+    """白名单过滤实体，并级联删除端点关系。"""
+    payload = {
+        "entities": [
+            {"name": "OpenAI", "type": "组织"},
+            {"name": "GPT", "type": "技术"},
+            {"name": "New York", "type": "地点"},
+        ],
+        "relations": [
+            {"source": "OpenAI", "target": "GPT", "type": "研发"},
+            {"source": "OpenAI", "target": "New York", "type": "位于"},
+        ],
+    }
+    extractor, _ = make_extractor([json.dumps(payload)], entity_types={"人物", "组织", "概念", "技术"})
+    graph = extractor.extract_from_chunk("文本", "chunk-1")
+    assert set(graph.entities) == {
+        entity_id("OpenAI", "组织"),
+        entity_id("GPT", "技术"),
+    }
+    assert [relation.type for relation in graph.relations] == ["研发"]
+
+
+@pytest.mark.parametrize(
+    "weight,expected",
+    [("bad", 1.0), (-0.5, 0.0), (1.5, 1.0)],
+)
+def test_relation_weight_is_normalized(weight, expected):
+    """非法 weight 回退，越界 weight 钳制到合法区间。"""
+    payload = {
+        "entities": [{"name": "A", "type": "概念"}, {"name": "B", "type": "概念"}],
+        "relations": [{"source": "A", "target": "B", "type": "相关", "weight": weight}],
+    }
+    extractor, _ = make_extractor([json.dumps(payload, ensure_ascii=False)])
+    graph = extractor.extract_from_chunk("A 与 B 相关", "chunk-1")
+    assert graph.relations[0].weight == pytest.approx(expected)
+
+
+def test_empty_chunk_and_empty_schema_return_empty_graph():
+    """空输入和空抽取 schema 都返回空图谱。"""
+    empty_schema = json.dumps({"entities": [], "relations": []})
+    extractor, llm = make_extractor([empty_schema, empty_schema])
+    assert extractor.extract_from_chunk("", "empty-chunk").to_dict() == {
+        "entities": [],
+        "relations": [],
+    }
+    assert extractor.extract_from_chunks([("empty-schema", "文本")]).to_dict() == {
+        "entities": [],
+        "relations": [],
+    }
+    assert len(llm.calls) == 2
+
+
+def test_extract_from_chunks_merges_and_records_failures():
+    """批量抽取合并同名同类型实体，并默认跳过失败 chunk。"""
+    first = {
+        "entities": [
+            {"name": "OpenAI", "type": "组织", "properties": {"a": 1}},
+            {"name": "GPT", "type": "技术"},
+        ],
+        "relations": [{"source": "OpenAI", "target": "GPT", "type": "研发"}],
+    }
+    third = {
+        "entities": [
+            {"name": "OpenAI", "type": "组织", "properties": {"b": 2}},
+            {"name": "Claude", "type": "技术"},
+        ],
+        "relations": [{"source": "OpenAI", "target": "Claude", "type": "对比"}],
+    }
+    extractor, llm = make_extractor(
+        [json.dumps(first), "bad", "bad", json.dumps(third)], max_retries=1
+    )
+    graph = extractor.extract_from_chunks(
+        [("chunk-1", "文本一"), ("chunk-2", "文本二"), ("chunk-3", "文本三")]
+    )
+    openai_id = entity_id("OpenAI", "组织")
+    assert graph.entities[openai_id].source_chunk_ids == ["chunk-1", "chunk-3"]
+    assert graph.entities[openai_id].properties == {"a": 1, "b": 2}
+    assert {relation.type for relation in graph.relations} == {"研发", "对比"}
+    assert extractor.last_run_stats == {
+        "total_chunks": 3,
+        "succeeded_chunks": 2,
+        "failed_chunks": ["chunk-2"],
+        "chunk_errors": extractor.last_run_stats["chunk_errors"],
+        "total_entities": 4,
+        "total_relations": 2,
+    }
+    assert len(llm.calls) == 4
+
+
+def test_extract_from_chunks_strict_raises_on_failure():
+    """strict 模式下失败 chunk 立即中断批量抽取。"""
+    extractor, llm = make_extractor(["bad", "bad", "bad"], max_retries=2)
+    with pytest.raises(GraphExtractionError):
+        extractor.extract_from_chunks([("chunk-1", "文本")], strict=True)
+    assert len(llm.calls) == 3
+    assert extractor.last_run_stats["failed_chunks"] == ["chunk-1"]
+
+
+def test_long_chunk_is_truncated_before_llm_call():
+    """超长输入先截断，不会传给 LLM 超限部分。"""
+    extractor, llm = make_extractor([json.dumps({"entities": [], "relations": []})], max_chunk_chars=20)
+    extractor.extract_from_chunk("A" * 21, "chunk-1")
+    assert "A" * 20 in llm.calls[0]["query"]
+    assert "A" * 21 not in llm.calls[0]["query"]
+
+
+def test_default_llm_client_is_created_lazily(monkeypatch):
+    """默认模型客户端只在首次抽取时创建。"""
+    default_llm = FakeLLM([json.dumps({"entities": [], "relations": []})])
+
+    class FakeModule:
+        """模拟惰性导入的模型模块。"""
+
+        @staticmethod
+        def get_openai_model():
+            """返回离线模型客户端。"""
+            return default_llm
+
+    monkeypatch.setitem(sys.modules, "core.llm.openai_llm_model", FakeModule)
+    extractor = LLMEntityRelationExtractor()
+
+    extractor.extract_from_chunk("文本", "chunk-1")
+
+    assert len(default_llm.calls) == 1


### PR DESCRIPTION
## 概要

知识图谱**阶段 B step2**：LLM 实体关系抽取器（stacked 在 **#27**（step1 数据模型）之上，base 分支为 `feat/kg-phase-b-step1-20260902`；#27 合入后本 PR 自动 retarget 到 main，届时 diff 仅含本步增量）。

- 新增 `core/graph/extractor.py`（462 行）：`LLMEntityRelationExtractor` + `GraphExtractionError`
  - 鸭子类型注入 LLM 客户端（兼容 `OpenAICompatibleLLM.generate_response`），默认客户端**惰性初始化**，模块导入零网络副作用
  - 输出契约：严格 JSON `{"entities":[...],"relations":[...]}`；容错解析（markdown 围栏/前后噪声/平衡对象截取）
  - **仅结构性错误触发重试**（错误原因回填 prompt 自纠，最多 `max_retries` 次，耗尽抛 `GraphExtractionError`）；关系端点缺失/白名单过滤属语义修正，直接丢弃并 warning，不消耗重试
  - 实体 `(name,type)` 去重 + properties 深合并；类型白名单级联删关系；weight 非法回退 1.0、越界钳制 [0,1]；实体/关系数量上限截断；超长 chunk 截断
  - 确定性 ID：`entity-{sha1(name|type)[:12]}`、`relation-{sha1(source|type|target)[:12]}`，支持跨 chunk 图谱合并
  - `extract_from_chunks` 批量抽取：跨 chunk 合并、失败 chunk 默认跳过（`strict=True` 则抛异常）、统计写入 `last_run_stats`
- 新增 `tests/test_graph_extractor.py`（247 行）：**14 条纯离线测试**（FakeLLM 注入，零联网）
- 更新 `core/graph/__init__.py`（+3 行导出）、`docs/knowledge-graph-design.md`（+38 行 step2 输出契约）
- 纯标准库，零新依赖，Python 3.8+；不改任何现有文件逻辑（4 文件 +750/-0）

## 验证证据（编排器独立复跑，2026-09-03 03:3x UTC）

| 闸门 | 结果 |
| --- | --- |
| flake8 新增文件 | **0 错误**（行长≤120） |
| flake8 全仓基线对比 | 与 step1 基线 **diff=0（零新增）**；F821/F823 预存 10 条不变 |
| pytest | **31 passed**（step1 基线 17 + 新增 14），0.15s |
| npm run lint | exit 0 |
| npm run build | exit 0（vite 274ms） |
| Playwright 冒烟 | **不适用**：本增量零前端改动（套件随 #26 合入后统一启用） |

代码 100% 由 Codex（`gpt-5.3-codex`）编写；闸门由编排器独立复跑验证。
提交：`81fa1f3`

## 后续

- step3：持久化 GraphStore 后端（生产可用存储）
- 依赖链：#26（阶段C 收尾）→ #27（step1）→ 本 PR
