### PR TITLE
feat(draft): 阶段B step3 - SQLite持久化GraphStore（原子事务+多库隔离）

### DIFF
--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -2,6 +2,7 @@
 
 from .extractor import GraphExtractionError, LLMEntityRelationExtractor
 from .models import Entity, GraphStore, InMemoryGraphStore, KnowledgeGraph, Relation
+from .store_sqlite import SqliteGraphStore
 
 __all__ = [
     "Entity",
@@ -11,4 +12,5 @@ __all__ = [
     "KnowledgeGraph",
     "LLMEntityRelationExtractor",
     "Relation",
+    "SqliteGraphStore",
 ]

--- a/core/graph/store_sqlite.py
+++ b/core/graph/store_sqlite.py
@@ -1,0 +1,186 @@
+"""基于 SQLite 的知识图谱持久化存储。"""
+
+import dataclasses
+import json
+import sqlite3
+from contextlib import closing
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from .models import Entity, GraphStore, KnowledgeGraph, Relation
+
+
+SCHEMA_VERSION = 1
+
+
+def _to_json_value(value: Any) -> Any:
+    """递归转换为 JSON 可序列化数据，并将时间转为 ISO8601。"""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _to_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_json_value(item) for item in value]
+    return value
+
+
+def _entity_to_dict(entity: Entity) -> Dict[str, Any]:
+    """将实体转换为 JSON 友好字典。"""
+    return _to_json_value(dataclasses.asdict(entity))
+
+
+def _entity_from_dict(data: Dict[str, Any]) -> Entity:
+    """从 JSON 字典恢复实体。"""
+    return Entity(
+        id=data["id"],
+        name=data["name"],
+        type=data["type"],
+        properties=dict(data.get("properties", {})),
+        source_chunk_ids=list(data.get("source_chunk_ids", [])),
+    )
+
+
+def _relation_to_dict(relation: Relation) -> Dict[str, Any]:
+    """将有向关系转换为 JSON 友好字典。"""
+    return _to_json_value(dataclasses.asdict(relation))
+
+
+def _relation_from_dict(data: Dict[str, Any]) -> Relation:
+    """从 JSON 字典恢复有向关系。"""
+    return Relation(
+        id=data["id"],
+        source_entity_id=data["source_entity_id"],
+        target_entity_id=data["target_entity_id"],
+        type=data["type"],
+        properties=dict(data.get("properties", {})),
+        weight=float(data.get("weight", 1.0)),
+    )
+
+
+def _knowledge_graph_to_dict(graph: KnowledgeGraph) -> Dict[str, Any]:
+    """将完整图谱转换为稳定 JSON 字典。"""
+    return {
+        "entities": [_entity_to_dict(entity) for entity in graph.entities.values()],
+        "relations": [_relation_to_dict(relation) for relation in graph.relations],
+    }
+
+
+def _knowledge_graph_from_dict(data: Dict[str, Any]) -> KnowledgeGraph:
+    """从 JSON 字典恢复完整图谱。"""
+    graph = KnowledgeGraph()
+    for entity_data in data.get("entities", []):
+        graph.add_entity(_entity_from_dict(entity_data))
+    for relation_data in data.get("relations", []):
+        graph.add_relation(_relation_from_dict(relation_data))
+    return graph
+
+
+class SqliteGraphStore(GraphStore):
+    """使用 SQLite 文件保存知识图谱的存储后端。
+
+    每次操作都会创建独立连接并立即关闭，因此同一个 store 实例可以在多个
+    线程中串行或并发使用；SQLite 自身的锁与 busy timeout 负责文件级并发。
+    """
+
+    def __init__(self, path: str = "easyrag_graph.db") -> None:
+        """初始化数据库文件和当前版本的表结构。
+
+        Args:
+            path: SQLite 数据库文件路径。
+
+        Raises:
+            RuntimeError: 已存在数据库使用不支持的 schema 版本。
+        """
+        self._path = path
+        self._initialize_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        """创建带基础超时配置的 SQLite 连接。"""
+        connection = sqlite3.connect(
+            self._path, timeout=30.0, check_same_thread=False
+        )
+        connection.execute("PRAGMA busy_timeout = 30000")
+        return connection
+
+    def _initialize_schema(self) -> None:
+        """创建 schema 表和图谱快照表，并写入当前版本。"""
+        with closing(self._connect()) as connection, connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    version INTEGER NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                "INSERT OR IGNORE INTO schema_version (id, version) VALUES (1, ?)",
+                (SCHEMA_VERSION,),
+            )
+            version = connection.execute(
+                "SELECT version FROM schema_version WHERE id = 1"
+            ).fetchone()[0]
+            if version != SCHEMA_VERSION:
+                raise RuntimeError(
+                    "不支持的图谱数据库 schema 版本: {}".format(version)
+                )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS knowledge_graphs (
+                    kb_id TEXT PRIMARY KEY,
+                    graph_data TEXT NOT NULL
+                )
+                """
+            )
+
+    def save(self, graph: KnowledgeGraph, kb_id: str) -> None:
+        """以单事务整体替换指定知识库的图谱。
+
+        Args:
+            graph: 待保存的知识图谱。
+            kb_id: 知识库 ID。
+
+        Raises:
+            sqlite3.Error: 事务失败时已回滚，旧图谱保持不变。
+        """
+        graph_data = json.dumps(
+            _knowledge_graph_to_dict(graph),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        with closing(self._connect()) as connection, connection:
+            connection.execute(
+                "DELETE FROM knowledge_graphs WHERE kb_id = ?", (kb_id,)
+            )
+            connection.execute(
+                "INSERT INTO knowledge_graphs (kb_id, graph_data) VALUES (?, ?)",
+                (kb_id, graph_data),
+            )
+
+    def load(self, kb_id: str) -> Optional[KnowledgeGraph]:
+        """读取指定知识库的图谱，不存在时返回 None。"""
+        with closing(self._connect()) as connection:
+            row = connection.execute(
+                "SELECT graph_data FROM knowledge_graphs WHERE kb_id = ?", (kb_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return _knowledge_graph_from_dict(json.loads(row[0]))
+
+    def delete(self, kb_id: str) -> bool:
+        """删除指定知识库的图谱，并返回是否删除成功。"""
+        with closing(self._connect()) as connection, connection:
+            cursor = connection.execute(
+                "DELETE FROM knowledge_graphs WHERE kb_id = ?", (kb_id,)
+            )
+            return cursor.rowcount > 0
+
+    def __enter__(self) -> "SqliteGraphStore":
+        """进入上下文管理器。"""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """退出上下文管理器。
+
+        连接在每次操作后均已关闭，这里无需额外释放资源。
+        """

--- a/tests/test_graph_store_sqlite.py
+++ b/tests/test_graph_store_sqlite.py
@@ -1,0 +1,170 @@
+"""SqliteGraphStore 单元测试。"""
+
+import sqlite3
+from datetime import datetime
+from threading import Thread
+
+import pytest
+
+from core.graph import Entity, KnowledgeGraph, Relation, SqliteGraphStore
+
+
+def make_graph(prefix: str = "entity") -> KnowledgeGraph:
+    """构造包含嵌套元数据和 ISO8601 时间的测试图谱。"""
+    graph = KnowledgeGraph()
+    graph.add_entity(
+        Entity(
+            id="{}-openai".format(prefix),
+            name="OpenAI",
+            type="organization",
+            properties={
+                "country": "America",
+                "tags": ["AI", "research"],
+                "updated_at": datetime(2026, 9, 4, 12, 30, 5),
+            },
+            source_chunk_ids=["chunk-1", "chunk-2"],
+        )
+    )
+    graph.add_entity(
+        Entity(id="{}-gpt".format(prefix), name="GPT", type="model")
+    )
+    graph.add_relation(
+        Relation(
+            id="{}-develops".format(prefix),
+            source_entity_id="{}-openai".format(prefix),
+            target_entity_id="{}-gpt".format(prefix),
+            type="develops",
+            properties={"since": 2018, "verified_at": datetime(2026, 1, 2, 3, 4, 5)},
+            weight=0.75,
+        )
+    )
+    return graph
+
+
+def with_iso_datetimes(
+    graph: KnowledgeGraph, prefix: str = "entity"
+) -> KnowledgeGraph:
+    """返回 datetime 已归一化为 ISO8601 字符串的期望图谱。"""
+    graph.get_entity("{}-openai".format(prefix)).properties["updated_at"] = (
+        "2026-09-04T12:30:05"
+    )
+    graph.relations[0].properties["verified_at"] = "2026-01-02T03:04:05"
+    return graph
+
+
+def test_save_load_round_trip(tmp_path) -> None:
+    """保存后读取的数据一致，datetime 按 ISO8601 字符串归一化。"""
+    graph = make_graph()
+    with SqliteGraphStore(str(tmp_path / "graph.db")) as store:
+        store.save(graph, "kb-1")
+        loaded = store.load("kb-1")
+
+    expected = with_iso_datetimes(make_graph())
+
+    assert loaded is not None
+    assert loaded.to_dict() == expected.to_dict()
+    assert loaded.entities == expected.entities
+    assert loaded.relations == expected.relations
+
+
+def test_multiple_knowledge_bases_are_isolated(tmp_path) -> None:
+    """写入一个知识库不会覆盖或影响另一个知识库。"""
+    first = make_graph("entity-a")
+    second = make_graph("entity-b")
+    first = with_iso_datetimes(first, "entity-a")
+    second = with_iso_datetimes(second, "entity-b")
+    store = SqliteGraphStore(str(tmp_path / "graph.db"))
+
+    store.save(first, "kb-a")
+    store.save(second, "kb-b")
+
+    assert store.load("kb-a").to_dict() == first.to_dict()
+    assert store.load("kb-b").to_dict() == second.to_dict()
+    store.delete("kb-a")
+    assert store.load("kb-a") is None
+    assert store.load("kb-b").to_dict() == second.to_dict()
+
+
+def test_delete_returns_false_when_missing(tmp_path) -> None:
+    """删除不存在和已删除的知识库都返回 False。"""
+    store = SqliteGraphStore(str(tmp_path / "graph.db"))
+    store.save(make_graph(), "kb-1")
+
+    assert store.delete("kb-1") is True
+    assert store.load("kb-1") is None
+    assert store.delete("kb-1") is False
+    assert store.delete("missing") is False
+
+
+def test_load_missing_returns_none(tmp_path) -> None:
+    """读取不存在的知识库返回 None。"""
+    store = SqliteGraphStore(str(tmp_path / "graph.db"))
+
+    assert store.load("missing") is None
+
+
+def test_schema_version_is_one(tmp_path) -> None:
+    """schema_version 表存在且记录当前版本 1。"""
+    database_path = str(tmp_path / "graph.db")
+    SqliteGraphStore(database_path)
+
+    with sqlite3.connect(database_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+        version = connection.execute("SELECT version FROM schema_version").fetchone()[0]
+
+    assert "schema_version" in tables
+    assert "knowledge_graphs" in tables
+    assert version == 1
+
+
+def test_save_replaces_old_graph_atomically(tmp_path) -> None:
+    """重复保存整体替换旧图，失败时旧图不被半写破坏。"""
+    old_graph = make_graph()
+    new_graph = make_graph()
+    database_path = str(tmp_path / "graph.db")
+    store = SqliteGraphStore(database_path)
+    store.save(old_graph, "kb-1")
+
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            CREATE TRIGGER fail_graph_insert
+            BEFORE INSERT ON knowledge_graphs
+            BEGIN
+                SELECT RAISE(ABORT, 'mock insert failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="mock insert failure"):
+        store.save(new_graph, "kb-1")
+
+    expected = with_iso_datetimes(make_graph())
+    loaded = store.load("kb-1")
+    assert loaded is not None
+    assert loaded.to_dict() == expected.to_dict()
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("DROP TRIGGER fail_graph_insert")
+    store.save(KnowledgeGraph(), "kb-1")
+    assert store.load("kb-1").to_dict() == {"entities": [], "relations": []}
+
+
+def test_store_instance_can_be_used_across_threads(tmp_path) -> None:
+    """check_same_thread=False 支持同一 store 实例跨线程访问。"""
+    store = SqliteGraphStore(str(tmp_path / "graph.db"))
+    errors = []
+
+    def load_graph() -> None:
+        try:
+            store.load("missing")
+        except Exception as error:
+            errors.append(error)
+
+    thread = Thread(target=load_graph)
+    thread.start()
+    thread.join()
+
+    assert errors == []


### PR DESCRIPTION
## 阶段B step3：持久化存储后端（SQLite）

> 堆叠在 #28（step2）之上，合并顺序建议：#27 → #28 → 本PR。设计文档见 #27 的 `docs/knowledge-graph-design.md`。

### 改动（commit ab53492，3 文件 +358 行）
- **新增 `core/graph/store_sqlite.py`（186 行）**：`SqliteGraphStore(GraphStore)`
  - 按 `kb_id` 隔离，多知识库共存互不影响
  - `save` 单事务原子整体替换（DELETE+INSERT 同一事务，失败自动回滚，旧图不损）
  - `schema_version` 表记录版本（当前 1），初始化时校验版本守卫，为未来迁移预留
  - 连接即开即关 + `busy_timeout=30s` + `check_same_thread=False`，支持跨线程/多实例文件级并发
  - datetime 递归归一化为 ISO8601 字符串往返；零新依赖（sqlite3/json/dataclasses 纯标准库），Python 3.8+
- **新增 `tests/test_graph_store_sqlite.py`（170 行）**：7 用例——save/load 往返一致、多库隔离、delete 语义（True/False）、load 缺失返回 None、schema 版本=1、**注入触发器模拟写失败验证事务回滚**、跨线程访问
- **修改 `core/graph/__init__.py`（+2）**：追加导出 `SqliteGraphStore`

### 验证证据（编排器独立复跑，非 codex 自报）
| 闸门 | 基线（step2 分支） | 本分支 | 结果 |
|---|---|---|---|
| pytest 全量 | 31 passed | **38 passed**（+7 新增，0 失败）0.33s | ✅ |
| flake8 全仓 | 2903 行存量（基线对比法） | 与基线 diff = **0 行**；新增 2 文件 + __init__ 单独跑 exit 0 | ✅ 零新增 |
| npm run lint | exit 0 | exit 0 | ✅ |
| npm run build (vite) | exit 0，271ms | exit 0，277ms | ✅ |
| Playwright 冒烟 | 不适用：零前端改动（套件在 #26 分支，合入后统一启用） | — | ✅ N/A |

- 代码 100% 由 Codex（gpt-5.3-codex）编写，编排器仅做闸门复跑与审查
- 未发布 easyrag.net，无线上校验项