### PR TITLE
feat(draft): 阶段B step4 - GraphQueryService查询服务与只读REST端点

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ if sys.platform.startswith('win'):
 print(f"系统默认编码: {locale.getpreferredencoding()}")
 print(f"Python默认编码: {sys.getdefaultencoding()}")
 
-from fastapi import FastAPI, HTTPException, UploadFile, File, Form, Body, Request, BackgroundTasks
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form, Body, Request, BackgroundTasks, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
@@ -42,6 +42,21 @@ from core.web_search.youcom_retriever import YouComWebRetriever
 # 添加进度跟踪字典
 # 格式: {task_id: {"status": "processing/completed/failed", "progress": 0-100, "message": "处理中..."}}
 processing_tasks = {}
+
+# 图谱查询服务懒加载单例，避免每次请求重复打开 SQLite 文件
+_graph_service = None
+
+
+def _get_graph_service():
+    """获取缓存的图谱查询服务实例。"""
+    global _graph_service
+    if _graph_service is None:
+        from core.graph import GraphQueryService, SqliteGraphStore
+
+        graph_db_path = os.environ.get("EASYRAG_GRAPH_DB_PATH", "easyrag_graph.db")
+        _graph_service = GraphQueryService(SqliteGraphStore(graph_db_path))
+    return _graph_service
+
 
 # 导入DeepSeek LLM模型
 from core.llm.local_llm_model import get_llm_model
@@ -173,6 +188,88 @@ async def get_knowledge_base_info(kb_name: str):
     except Exception as e:
         error_trace = traceback.format_exc()
         raise HTTPException(status_code=500, detail=f"获取知识库信息失败: {str(e)}\n{error_trace}")
+
+
+@app.get("/kb/graph/{kb_name}")
+async def get_knowledge_graph(kb_name: str):
+    """获取指定知识库的完整图谱"""
+    try:
+        graph = _get_graph_service().get_graph(kb_name)
+        if graph is None:
+            raise HTTPException(status_code=404, detail=f"知识库 {kb_name} 的图谱不存在")
+        return graph
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_trace = traceback.format_exc()
+        raise HTTPException(status_code=500, detail=f"获取知识图谱失败: {str(e)}\n{error_trace}")
+
+
+@app.get("/kb/graph/{kb_name}/entities")
+async def list_graph_entities(
+    kb_name: str,
+    type: Optional[str] = Query(None),
+    name: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    """分页查询指定知识库的图谱实体"""
+    try:
+        return _get_graph_service().list_entities(
+            kb_name,
+            entity_type=type,
+            name=name,
+            limit=limit,
+            offset=offset,
+        )
+    except Exception as e:
+        error_trace = traceback.format_exc()
+        raise HTTPException(status_code=500, detail=f"查询图谱实体失败: {str(e)}\n{error_trace}")
+
+
+@app.get("/kb/graph/{kb_name}/entities/{entity_id}")
+async def get_graph_entity(
+    kb_name: str,
+    entity_id: str,
+    direction: str = Query("both", pattern="^(in|out|both)$"),
+):
+    """查询图谱实体详情及一度关系"""
+    try:
+        neighborhood = _get_graph_service().get_entity_neighborhood(
+            kb_name,
+            entity_id,
+            direction=direction,
+        )
+        if neighborhood is None:
+            raise HTTPException(status_code=404, detail=f"实体 {entity_id} 不存在")
+        return neighborhood
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_trace = traceback.format_exc()
+        raise HTTPException(status_code=500, detail=f"查询图谱实体详情失败: {str(e)}\n{error_trace}")
+
+
+@app.get("/kb/graph/{kb_name}/relations")
+async def list_graph_relations(
+    kb_name: str,
+    entity_id: Optional[str] = Query(None),
+    type: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+):
+    """分页查询指定知识库的图谱关系"""
+    try:
+        return _get_graph_service().list_relations(
+            kb_name,
+            entity_id=entity_id,
+            relation_type=type,
+            limit=limit,
+            offset=offset,
+        )
+    except Exception as e:
+        error_trace = traceback.format_exc()
+        raise HTTPException(status_code=500, detail=f"查询图谱关系失败: {str(e)}\n{error_trace}")
 
 @app.delete("/kb/delete/{kb_name}")
 async def delete_knowledge_base(kb_name: str):

--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -1,12 +1,14 @@
 """知识图谱模块。"""
 
 from .extractor import GraphExtractionError, LLMEntityRelationExtractor
+from .service import GraphQueryService
 from .models import Entity, GraphStore, InMemoryGraphStore, KnowledgeGraph, Relation
 from .store_sqlite import SqliteGraphStore
 
 __all__ = [
     "Entity",
     "GraphExtractionError",
+    "GraphQueryService",
     "GraphStore",
     "InMemoryGraphStore",
     "KnowledgeGraph",

--- a/core/graph/service.py
+++ b/core/graph/service.py
@@ -1,0 +1,185 @@
+"""知识图谱查询服务。"""
+
+from typing import Any, Dict, Optional
+
+from .models import Entity, GraphStore, Relation
+
+
+class GraphQueryService:
+    """提供面向知识图谱的纯内存查询能力。"""
+
+    def __init__(self, store: GraphStore) -> None:
+        """初始化图谱存储后端。
+
+        Args:
+            store: 任意实现了 ``GraphStore`` 接口的存储实例。
+        """
+        self._store = store
+
+    def get_graph(self, kb_id: str) -> Optional[Dict[str, Any]]:
+        """获取指定知识库的完整图谱。"""
+        graph = self._store.load(kb_id)
+        if graph is None:
+            return None
+        return graph.to_dict()
+
+    def list_entities(
+        self,
+        kb_id: str,
+        entity_type: Optional[str] = None,
+        name: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """分页查询实体，并支持类型与名称精确过滤。"""
+        graph = self._store.load(kb_id)
+        if graph is None:
+            return {"items": [], "total": 0}
+
+        entities = sorted(graph.entities.values(), key=lambda entity: entity.id)
+        entities = [
+            entity
+            for entity in entities
+            if (entity_type is None or entity.type == entity_type)
+            and (name is None or entity.name == name)
+        ]
+        actual_limit = self._clamp_limit(limit)
+        actual_offset = self._clamp_offset(offset)
+        return {
+            "items": [
+                self._entity_to_dict(entity)
+                for entity in entities[actual_offset : actual_offset + actual_limit]
+            ],
+            "total": len(entities),
+        }
+
+    def get_entity(self, kb_id: str, entity_id: str) -> Optional[Dict[str, Any]]:
+        """按 ID 查询实体详情。"""
+        graph = self._store.load(kb_id)
+        if graph is None:
+            return None
+        entity = graph.get_entity(entity_id)
+        if entity is None:
+            return None
+        return self._entity_to_dict(entity)
+
+    def get_entity_neighborhood(
+        self,
+        kb_id: str,
+        entity_id: str,
+        direction: str = "both",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Optional[Dict[str, Any]]:
+        """查询实体详情及其一度关系。"""
+        graph = self._store.load(kb_id)
+        if graph is None:
+            return None
+        entity = graph.get_entity(entity_id)
+        if entity is None:
+            return None
+
+        relations = sorted(
+            graph.get_relations(entity_id),
+            key=lambda relation: relation.id,
+        )
+        relations = [
+            relation
+            for relation in relations
+            if self._relation_matches_direction(relation, entity_id, direction)
+        ]
+        actual_limit = self._clamp_limit(limit)
+        actual_offset = self._clamp_offset(offset)
+        return {
+            "entity": self._entity_to_dict(entity),
+            "relations": [
+                self._relation_to_dict(relation)
+                for relation in relations[
+                    actual_offset : actual_offset + actual_limit
+                ]
+            ],
+            "total": len(relations),
+        }
+
+    def list_relations(
+        self,
+        kb_id: str,
+        entity_id: Optional[str] = None,
+        relation_type: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """分页查询关系，并支持实体与类型精确过滤。"""
+        graph = self._store.load(kb_id)
+        if graph is None:
+            return {"items": [], "total": 0}
+
+        relations = sorted(
+            graph.get_relations(entity_id),
+            key=lambda relation: relation.id,
+        )
+        relations = [
+            relation
+            for relation in relations
+            if relation_type is None or relation.type == relation_type
+        ]
+        actual_limit = self._clamp_limit(limit)
+        actual_offset = self._clamp_offset(offset)
+        return {
+            "items": [
+                self._relation_to_dict(relation)
+                for relation in relations[
+                    actual_offset : actual_offset + actual_limit
+                ]
+            ],
+            "total": len(relations),
+        }
+
+    @staticmethod
+    def _entity_to_dict(entity: Entity) -> Dict[str, Any]:
+        """转换实体为 JSON 友好结构。"""
+        return {
+            "id": entity.id,
+            "name": entity.name,
+            "type": entity.type,
+            "properties": dict(entity.properties),
+            "source_chunk_ids": list(entity.source_chunk_ids),
+        }
+
+    @staticmethod
+    def _relation_to_dict(relation: Relation) -> Dict[str, Any]:
+        """转换关系为 JSON 友好结构。"""
+        return {
+            "id": relation.id,
+            "source_entity_id": relation.source_entity_id,
+            "target_entity_id": relation.target_entity_id,
+            "type": relation.type,
+            "properties": dict(relation.properties),
+            "weight": relation.weight,
+        }
+
+    @staticmethod
+    def _relation_matches_direction(
+        relation: Relation, entity_id: str, direction: str
+    ) -> bool:
+        """判断关系是否匹配指定方向。"""
+        if direction == "out":
+            return relation.source_entity_id == entity_id
+        if direction == "in":
+            return relation.target_entity_id == entity_id
+        if direction == "both":
+            return (
+                relation.source_entity_id == entity_id
+                or relation.target_entity_id == entity_id
+            )
+        return False
+
+    @staticmethod
+    def _clamp_limit(limit: int) -> int:
+        """将分页大小钳制到有效区间。"""
+        return min(max(limit, 1), 500)
+
+    @staticmethod
+    def _clamp_offset(offset: int) -> int:
+        """将分页偏移钳制为非负整数。"""
+        return max(offset, 0)

--- a/tests/test_graph_service.py
+++ b/tests/test_graph_service.py
@@ -1,0 +1,231 @@
+"""知识图谱查询服务离线单元测试。"""
+
+import pytest
+
+from core.graph import (
+    Entity,
+    GraphQueryService,
+    GraphStore,
+    InMemoryGraphStore,
+    KnowledgeGraph,
+    Relation,
+    SqliteGraphStore,
+)
+
+
+def make_store(backend: str, tmp_path) -> GraphStore:
+    """创建待测试的图谱存储后端。"""
+    if backend == "memory":
+        return InMemoryGraphStore()
+    return SqliteGraphStore(str(tmp_path / "graph.db"))
+
+
+def make_graph() -> KnowledgeGraph:
+    """构造顺序刻意乱序，用于验证确定性排序。"""
+    graph = KnowledgeGraph()
+    graph.add_entity(
+        Entity(
+            id="entity-c",
+            name="Python",
+            type="language",
+            properties={"birth_year": 1991},
+            source_chunk_ids=["chunk-1"],
+        )
+    )
+    graph.add_entity(Entity(id="entity-a", name="OpenAI", type="company"))
+    graph.add_entity(Entity(id="entity-b", name="GPT", type="model"))
+    graph.add_entity(Entity(id="entity-d", name="Python SDK", type="model"))
+    graph.add_relation(
+        Relation(
+            id="relation-c",
+            source_entity_id="entity-b",
+            target_entity_id="entity-a",
+            type="owned_by",
+            weight=0.8,
+        )
+    )
+    graph.add_relation(
+        Relation(
+            id="relation-a",
+            source_entity_id="entity-a",
+            target_entity_id="entity-b",
+            type="develops",
+            properties={"since": 2018},
+            weight=0.9,
+        )
+    )
+    graph.add_relation(
+        Relation(
+            id="relation-b",
+            source_entity_id="entity-c",
+            target_entity_id="entity-b",
+            type="develops",
+            weight=0.7,
+        )
+    )
+    graph.add_relation(
+        Relation(
+            id="relation-d",
+            source_entity_id="entity-d",
+            target_entity_id="entity-a",
+            type="owned_by",
+            weight=0.6,
+        )
+    )
+    return graph
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_get_graph_hit_and_missing(backend: str, tmp_path) -> None:
+    """完整图谱命中时返回序列化结果，缺失时返回 None。"""
+    graph = make_graph()
+    store = make_store(backend, tmp_path)
+    store.save(graph, "kb-1")
+    service = GraphQueryService(store)
+
+    assert service.get_graph("kb-1") == graph.to_dict()
+    assert service.get_graph("missing-kb") is None
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_list_entities_filters_pagination_and_clamps(
+    backend: str, tmp_path
+) -> None:
+    """实体列表支持精确过滤、稳定分页与参数钳制。"""
+    graph = make_graph()
+    store = make_store(backend, tmp_path)
+    store.save(graph, "kb-1")
+    service = GraphQueryService(store)
+
+    result = service.list_entities("kb-1")
+    assert [item["id"] for item in result["items"]] == [
+        "entity-a",
+        "entity-b",
+        "entity-c",
+        "entity-d",
+    ]
+    assert result["total"] == 4
+
+    result = service.list_entities("kb-1", entity_type="model")
+    assert [item["id"] for item in result["items"]] == ["entity-b", "entity-d"]
+    assert result["total"] == 2
+
+    result = service.list_entities("kb-1", name="OpenAI")
+    assert [item["id"] for item in result["items"]] == ["entity-a"]
+    assert result["items"][0]["properties"] == {}
+    assert result["items"][0]["source_chunk_ids"] == []
+
+    result = service.list_entities("kb-1", limit=2, offset=1)
+    assert [item["id"] for item in result["items"]] == ["entity-b", "entity-c"]
+    assert result["total"] == 4
+    clamped = service.list_entities("kb-1", limit=0, offset=-10)
+    assert [item["id"] for item in clamped["items"]] == ["entity-a"]
+    assert service.list_entities("kb-1", limit=0, offset=-10)["total"] == 4
+    assert service.list_entities("kb-1", limit=1000)["total"] == 4
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_get_entity_hit_and_missing(backend: str, tmp_path) -> None:
+    """实体详情返回完整实体结构。"""
+    graph = make_graph()
+    store = make_store(backend, tmp_path)
+    store.save(graph, "kb-1")
+    service = GraphQueryService(store)
+
+    entity = service.get_entity("kb-1", "entity-c")
+    assert entity == graph.get_entity("entity-c").__dict__
+    assert service.get_entity("kb-1", "missing-entity") is None
+    assert service.get_entity("missing-kb", "entity-c") is None
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_entity_neighborhood_directions_and_missing(
+    backend: str, tmp_path
+) -> None:
+    """邻域查询按方向过滤并保持关系 ID 升序。"""
+    graph = make_graph()
+    store = make_store(backend, tmp_path)
+    store.save(graph, "kb-1")
+    service = GraphQueryService(store)
+
+    both = service.get_entity_neighborhood("kb-1", "entity-a")
+    assert both is not None
+    assert both["entity"]["id"] == "entity-a"
+    assert [item["id"] for item in both["relations"]] == [
+        "relation-a",
+        "relation-c",
+        "relation-d",
+    ]
+    assert both["total"] == 3
+
+    outgoing = service.get_entity_neighborhood("kb-1", "entity-a", direction="out")
+    assert outgoing is not None
+    assert [item["id"] for item in outgoing["relations"]] == ["relation-a"]
+    assert outgoing["total"] == 1
+
+    incoming = service.get_entity_neighborhood("kb-1", "entity-a", direction="in")
+    assert incoming is not None
+    assert [item["id"] for item in incoming["relations"]] == [
+        "relation-c",
+        "relation-d",
+    ]
+    assert incoming["total"] == 2
+    assert incoming["relations"][0]["properties"] == {}
+
+    assert service.get_entity_neighborhood("kb-1", "missing-entity") is None
+    assert service.get_entity_neighborhood("missing-kb", "entity-a") is None
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_list_relations_filters_pagination_and_clamps(
+    backend: str, tmp_path
+) -> None:
+    """关系列表支持实体、类型过滤和稳定分页。"""
+    graph = make_graph()
+    store = make_store(backend, tmp_path)
+    store.save(graph, "kb-1")
+    service = GraphQueryService(store)
+
+    result = service.list_relations("kb-1")
+    assert [item["id"] for item in result["items"]] == [
+        "relation-a",
+        "relation-b",
+        "relation-c",
+        "relation-d",
+    ]
+    assert result["total"] == 4
+
+    result = service.list_relations("kb-1", entity_id="entity-a")
+    assert [item["id"] for item in result["items"]] == [
+        "relation-a",
+        "relation-c",
+        "relation-d",
+    ]
+    assert result["total"] == 3
+
+    result = service.list_relations("kb-1", relation_type="develops")
+    assert [item["id"] for item in result["items"]] == [
+        "relation-a",
+        "relation-b",
+    ]
+    assert result["total"] == 2
+
+    result = service.list_relations(
+        "kb-1", relation_type="develops", limit=1, offset=1
+    )
+    assert [item["id"] for item in result["items"]] == ["relation-b"]
+    assert result["total"] == 2
+
+    result = service.list_relations("kb-1", limit=0, offset=-10)
+    assert [item["id"] for item in result["items"]] == ["relation-a"]
+    assert result["total"] == 4
+    assert service.list_relations("kb-1", limit=1000)["total"] == 4
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_missing_graph_lists_are_empty(backend: str, tmp_path) -> None:
+    """知识库图谱不存在时列表返回空结果。"""
+    service = GraphQueryService(make_store(backend, tmp_path))
+
+    assert service.list_entities("missing-kb") == {"items": [], "total": 0}
+    assert service.list_relations("missing-kb") == {"items": [], "total": 0}


### PR DESCRIPTION
## 概述
阶段B（知识图谱）第四步增量：**GraphStore 查询接口层**。新增 `GraphQueryService` 查询服务与 4 个只读 REST 端点，将 step3 的 SQLite GraphStore 以懒加载单例接入 FastAPI 应用。不含 LLM 抽取接入（留待 step5 图谱构建端点）。

## 改动内容（4 文件，+517/-2）
- **core/graph/service.py**（新增 185 行）：`GraphQueryService`
  - `get_graph` / `list_entities`（type/name 精确过滤）/ `get_entity` / `get_entity_neighborhood`（direction in|out|both）/ `list_relations`（entity_id/relation_type 过滤）
  - 按 id 升序稳定分页；limit 钳制 [1,500]、offset ≥0；图谱不存在时 get_* 返回 None、list_* 返回空集
- **app.py**（+94/-2）：4 个只读端点
  - `GET /kb/graph/{kb_name}`（不存在 404）
  - `GET /kb/graph/{kb_name}/entities?type=&name=&limit=&offset=`
  - `GET /kb/graph/{kb_name}/entities/{entity_id}?direction=`（详情+一度关系）
  - `GET /kb/graph/{kb_name}/relations?entity_id=&type=&limit=&offset=`
  - 惰性单例 `SqliteGraphStore`，路径由 `EASYRAG_GRAPH_DB_PATH` 配置（默认 easyrag_graph.db）；错误处理与现有 /kb/* 端点风格一致
- **tests/test_graph_service.py**（新增 231 行）：12 条参数化离线测试（InMemoryGraphStore + SqliteGraphStore(tmp_path) 双后端同组断言），覆盖过滤/排序/分页/钳制/方向/缺失图谱；不 import app、无网络/LLM
- **core/graph/__init__.py**：导出 `GraphQueryService`

## 验证证据（闸门全通过）
| 闸门 | 结果 |
| --- | --- |
| pytest 全量 | **50 passed in 0.49s**（基线38 + 新增12，含双后端参数化） |
| flake8 全仓基线对比 | **规则分布与基线完全一致**（总条数 2903→2902，唯一差异 W292 -1：修复 app.py 文件末尾缺换行；新文件 0 告警；app.py E302=27/E402=9/E305=1 与基线持平） |
| py_compile | app.py + core/graph/service.py OK |
| Playwright 冒烟 | 不适用（纯后端改动，未触及前端） |
| npm lint/build | 未复跑（纯后端 4 文件，沿用 step2/3 先例；前端零改动） |

## 实现说明
- 代码由 Codex（gpt-5.3-codex）编写（会话 02:45-02:53Z，两轮：实现+flake8 收尾修正）
- 第一轮实现后 flake8 基线对比发现 app.py +6 新告警（5×E302/1×E402/1×E305），已由 Codex 二轮修正归零（含将 graph 导入改为函数内惰性导入）

## 依赖链（stacked）
#26 → #27 → #28 → #29 → **本 PR**，建议按序合并。