### PR TITLE
feat(draft): 阶段B step5 - 图谱构建触发端点（GraphBuildService + POST extract）

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import os.path
 import time
 import locale
 from urllib.parse import quote, unquote
-from typing import List, Dict, Any, Optional, Union
+from typing import List, Dict, Any, Optional, Tuple, Union
 
 
 # 设置默认编码为UTF-8
@@ -45,6 +45,7 @@ processing_tasks = {}
 
 # 图谱查询服务懒加载单例，避免每次请求重复打开 SQLite 文件
 _graph_service = None
+_graph_builder = None
 
 
 def _get_graph_service():
@@ -56,6 +57,36 @@ def _get_graph_service():
         graph_db_path = os.environ.get("EASYRAG_GRAPH_DB_PATH", "easyrag_graph.db")
         _graph_service = GraphQueryService(SqliteGraphStore(graph_db_path))
     return _graph_service
+
+
+def _get_graph_builder():
+    """获取缓存的图谱构建服务实例。"""
+    global _graph_builder
+    if _graph_builder is None:
+        from core.graph import GraphBuildService, LLMEntityRelationExtractor, SqliteGraphStore
+
+        graph_db_path = os.environ.get("EASYRAG_GRAPH_DB_PATH", "easyrag_graph.db")
+        _graph_builder = GraphBuildService(
+            LLMEntityRelationExtractor(),
+            SqliteGraphStore(graph_db_path),
+        )
+    return _graph_builder
+
+
+def _collect_graph_chunks(vector_db, kb_name: str) -> List[Tuple[str, str]]:
+    """从向量库元数据中收集待抽取的文本块。"""
+    collection_metadata = vector_db.metadata.get(kb_name, [])
+    if isinstance(collection_metadata, dict):
+        collection_metadata = [
+            collection_metadata[key]
+            for key in sorted(collection_metadata, key=lambda value: int(value))
+        ]
+
+    return [
+        (str(document.get("id", "doc-{}".format(index))), str(document["text"]))
+        for index, document in enumerate(collection_metadata)
+        if isinstance(document, dict) and document.get("text")
+    ]
 
 
 # 导入DeepSeek LLM模型
@@ -270,6 +301,50 @@ async def list_graph_relations(
     except Exception as e:
         error_trace = traceback.format_exc()
         raise HTTPException(status_code=500, detail=f"查询图谱关系失败: {str(e)}\n{error_trace}")
+
+
+@app.post("/kb/graph/{kb_name}/extract")
+async def extract_knowledge_graph(
+    kb_name: str,
+    max_chunks: int = Query(0, ge=0),
+):
+    """从知识库已存储文本构建知识图谱"""
+    from core.graph import GraphExtractionError
+
+    try:
+        global rag_service
+        if not rag_service:
+            rag_service = RAGService()
+
+        if not rag_service.kb_exists(kb_name):
+            raise HTTPException(status_code=404, detail=f"知识库 {kb_name} 不存在")
+
+        vector_db = rag_service.vector_db
+        if kb_name not in vector_db.metadata and not vector_db.load_collection(kb_name):
+            raise HTTPException(
+                status_code=400,
+                detail=f"知识库 {kb_name} 中没有可用的文本块",
+            )
+
+        chunks = _collect_graph_chunks(vector_db, kb_name)
+
+        stats = _get_graph_builder().build(
+            kb_name,
+            _get_graph_builder().limit_chunks(chunks, max_chunks),
+        )
+        return {"status": "success", "data": stats}
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except GraphExtractionError as exc:
+        raise HTTPException(status_code=500, detail=f"图谱抽取失败: {str(exc)}")
+    except Exception as e:
+        error_trace = traceback.format_exc()
+        raise HTTPException(
+            status_code=500,
+            detail=f"构建知识图谱失败: {str(e)}\n{error_trace}",
+        )
 
 @app.delete("/kb/delete/{kb_name}")
 async def delete_knowledge_base(kb_name: str):

--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -1,6 +1,7 @@
 """知识图谱模块。"""
 
 from .extractor import GraphExtractionError, LLMEntityRelationExtractor
+from .builder import GraphBuildService
 from .service import GraphQueryService
 from .models import Entity, GraphStore, InMemoryGraphStore, KnowledgeGraph, Relation
 from .store_sqlite import SqliteGraphStore
@@ -8,6 +9,7 @@ from .store_sqlite import SqliteGraphStore
 __all__ = [
     "Entity",
     "GraphExtractionError",
+    "GraphBuildService",
     "GraphQueryService",
     "GraphStore",
     "InMemoryGraphStore",

--- a/core/graph/builder.py
+++ b/core/graph/builder.py
@@ -1,0 +1,90 @@
+"""知识图谱构建服务。"""
+
+from typing import Any, Dict, List, Tuple
+
+from .extractor import LLMEntityRelationExtractor
+from .models import GraphStore
+
+
+class GraphBuildService:
+    """串联文本抽取与存储，构建指定知识库的图谱。"""
+
+    def __init__(
+        self,
+        extractor: LLMEntityRelationExtractor,
+        store: GraphStore,
+    ) -> None:
+        """初始化图谱构建依赖。
+
+        Args:
+            extractor: 负责从文本 chunk 抽取实体与关系的抽取器。
+            store: 任意实现 ``GraphStore`` 接口的图谱存储实例。
+        """
+        self._extractor = extractor
+        self._store = store
+
+    def build(
+        self, kb_name: str, chunks: List[Tuple[str, str]]
+    ) -> Dict[str, Any]:
+        """抽取文本 chunk 并原子替换指定知识库的图谱。
+
+        Args:
+            kb_name: 知识库名称。
+            chunks: ``(chunk_id, text)`` 列表。
+
+        Returns:
+            构建统计信息。除基础统计外，还会并入抽取器最近一次
+            ``total_chunks``、``succeeded_chunks``、``failed_chunks``、
+            ``chunk_errors`` 等运行字段。
+
+        Raises:
+            ValueError: 知识库没有可用的文本块。
+        """
+        if not chunks:
+            raise ValueError("知识库中没有可用的文本块")
+
+        graph = self._extractor.extract_from_chunks(chunks, strict=False)
+        self._store.save(graph, kb_name)
+
+        stats: Dict[str, Any] = {
+            # 知识库名称
+            "kb_name": kb_name,
+            # 参与构建的文本块总数
+            "chunks_total": len(chunks),
+            # 最终保存的去重后实体数
+            "entities": len(graph.entities),
+            # 最终保存的关系数
+            "relations": len(graph.relations),
+        }
+        stats.update(self._extractor.last_run_stats)
+        return stats
+
+    @staticmethod
+    def limit_chunks(
+        chunks: List[Tuple[str, str]], max_chunks: int
+    ) -> List[Tuple[str, str]]:
+        """按上限截断待构建 chunk，正数生效，0 表示不限制。"""
+        if max_chunks < 0:
+            raise ValueError("max_chunks 不能小于 0")
+        return chunks if max_chunks == 0 else chunks[:max_chunks]
+
+    def build_from_documents(
+        self, kb_name: str, documents: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """将本仓库存储的 chunk 字典转换后构建图谱。
+
+        Args:
+            kb_name: 知识库名称。
+            documents: ``add_documents`` 保存的 chunk 字典列表。
+
+        Returns:
+            构建统计信息，字段与 :meth:`build` 一致。
+
+        Raises:
+            ValueError: 知识库没有可用的文本块。
+        """
+        chunks = [
+            (str(document.get("id", "doc-{}".format(index))), str(document["text"]))
+            for index, document in enumerate(documents)
+        ]
+        return self.build(kb_name, chunks)

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -1,0 +1,145 @@
+"""GraphBuildService 离线单元测试。"""
+
+import json
+import hashlib
+
+import pytest
+
+from core.graph import LLMEntityRelationExtractor, SqliteGraphStore
+from core.graph.builder import GraphBuildService
+
+
+class FakeLLM:
+    """按调用顺序返回预设响应的离线 LLM。"""
+
+    def __init__(self, responses):
+        """保存预设响应并初始化调用记录。"""
+        self.responses = list(responses)
+        self.calls = []
+
+    def generate_response(self, query, temperature=None, max_length=None):
+        """记录请求并返回下一条预设响应。"""
+        self.calls.append({"query": query, "temperature": temperature})
+        if not self.responses:
+            raise AssertionError("FakeLLM 响应已耗尽")
+        return self.responses.pop(0)
+
+
+def make_service(tmp_path, responses, **kwargs):
+    """构造使用临时 SQLite 存储的构建服务。"""
+    llm = FakeLLM(responses)
+    service = GraphBuildService(
+        LLMEntityRelationExtractor(llm_client=llm, **kwargs),
+        SqliteGraphStore(str(tmp_path / "graph.db")),
+    )
+    return service, llm, service._store
+
+
+@pytest.mark.parametrize(
+    ("payloads", "expected"),
+    [
+        (
+            [
+                {
+                    "entities": [
+                        {"name": "OpenAI", "type": "组织"},
+                        {"name": "GPT", "type": "技术"},
+                    ],
+                    "relations": [
+                        {"source": "OpenAI", "target": "GPT", "type": "研发"}
+                    ],
+                }
+            ],
+            (2, 1),
+        ),
+        ([{"entities": [], "relations": []}], (0, 0)),
+    ],
+)
+def test_build_saves_graph_and_returns_stats(tmp_path, payloads, expected):
+    """正常构建会保存去重图谱，并返回抽取运行统计。"""
+    responses = [json.dumps(payload) for payload in payloads]
+    service, llm, _ = make_service(tmp_path, responses)
+
+    stats = service.build("kb-1", [("chunk-1", "OpenAI 研发 GPT")])
+
+    assert (stats["entities"], stats["relations"]) == expected
+    assert stats["kb_name"] == "kb-1"
+    assert stats["chunks_total"] == 1
+    assert stats["total_chunks"] == 1
+    assert stats["succeeded_chunks"] == 1
+    assert stats["failed_chunks"] == []
+    assert len(llm.calls) == 1
+
+
+def test_build_from_documents_uses_document_id_and_fallback(tmp_path):
+    """文档自带 id 时优先使用，缺失时按索引兜底。"""
+    payload = {
+        "entities": [{"name": "OpenAI", "type": "组织"}],
+        "relations": [],
+    }
+    service, _, store = make_service(tmp_path, [json.dumps(payload)] * 2)
+    documents = [
+        {"id": "custom-id", "text": "OpenAI"},
+        {"text": "OpenAI"},
+    ]
+
+    stats = service.build_from_documents("kb-1", documents)
+
+    assert stats["succeeded_chunks"] == 2
+    entity_id = "entity-" + hashlib.sha1("OpenAI|组织".encode()).hexdigest()[:12]
+    assert store.load("kb-1").entities[entity_id].source_chunk_ids == [
+        "custom-id",
+        "doc-1",
+    ]
+
+
+def test_build_without_chunks_raises_value_error(tmp_path):
+    """空 chunk 列表在调用 LLM 前直接失败。"""
+    service, llm, _ = make_service(tmp_path, [])
+
+    with pytest.raises(ValueError, match="知识库中没有可用的文本块"):
+        service.build("kb-1", [])
+
+    assert llm.calls == []
+
+
+def test_build_tolerates_single_chunk_failure(tmp_path):
+    """strict=False 时单 chunk 失败不阻断其他文本抽取和落库。"""
+    valid = {
+        "entities": [{"name": "OpenAI", "type": "组织"}],
+        "relations": [],
+    }
+    service, llm, store = make_service(
+        tmp_path,
+        [json.dumps(valid), "bad", "bad", json.dumps(valid)],
+        max_retries=1,
+    )
+
+    stats = service.build(
+        "kb-1",
+        [("chunk-1", "有效"), ("chunk-2", "无效"), ("chunk-3", "有效")],
+    )
+
+    assert stats["succeeded_chunks"] == 2
+    assert stats["failed_chunks"] == ["chunk-2"]
+    assert len(stats["chunk_errors"]) == 1
+    assert len(llm.calls) == 4
+    assert len(store.load("kb-1").entities) == 1
+
+
+@pytest.mark.parametrize(
+    ("max_chunks", "expected"),
+    [
+        (0, ["doc-0", "doc-1", "doc-2"]),
+        (2, ["doc-0", "doc-1"]),
+    ],
+)
+def test_extract_endpoint_applies_max_chunks(monkeypatch, max_chunks, expected):
+    """max_chunks 为 0 时不截断，正数时只保留前 N 个 chunk。"""
+    chunks = [
+        ("doc-0", "文本一"),
+        ("doc-1", "文本二"),
+        ("doc-2", "文本三"),
+    ]
+
+    assert GraphBuildService.limit_chunks(chunks, max_chunks) == chunks[: len(expected)]


### PR DESCRIPTION
## 内容
- `core/graph/builder.py`：GraphBuildService —— 从已入库 chunk 构建图谱（LLM 抽取 + GraphStore 持久化），limit_chunks 截断（0=不限，负数 ValueError）
- `app.py`：`POST /kb/graph/{kb_name}/extract?max_chunks=N` 构建触发端点（404/400 语义错误、GraphExtractionError→500）；chunk 收集逻辑提取为 `_collect_graph_chunks()` 辅助函数（同时消除与 limit_chunks 重复的截断）
- `tests/test_graph_builder.py`：7 条离线测试（fake 抽取器 + 内存 store）
- `core/graph/__init__.py`：导出更新

## 闸门证据（心跳独立复核，2026-09-06 02:55Z）
- pytest **57 passed**（50+7，0.59s）
- flake8 全仓 **2902 = 基线**（首查 +1 C901 extract_knowledge_graph 复杂度11 → 收尾轮以辅助函数提取修复 → 复测归零）
- py_compile OK；npm/Playwright 不适用（纯后端）

## 依赖链
#26 → #27 → #28 → #29 → #30 → **本 PR**（第6层 stacked）