### PR TITLE
feat(draft): 阶段B step6 - 图谱删除联动（DELETE graph 端点 + kb 删除联动清理）

### DIFF
--- a/app.py
+++ b/app.py
@@ -221,6 +221,21 @@ async def get_knowledge_base_info(kb_name: str):
         raise HTTPException(status_code=500, detail=f"获取知识库信息失败: {str(e)}\n{error_trace}")
 
 
+@app.delete("/kb/graph/{kb_name}")
+async def delete_knowledge_graph(kb_name: str):
+    """删除指定知识库的完整图谱"""
+    try:
+        graph_deleted = _get_graph_service().delete_graph(kb_name)
+        if not graph_deleted:
+            raise HTTPException(status_code=404, detail=f"知识库 {kb_name} 的图谱不存在")
+        return {"status": "success", "message": f"成功删除知识图谱：{kb_name}"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_trace = traceback.format_exc()
+        raise HTTPException(status_code=500, detail=f"删除知识图谱失败: {str(e)}\n{error_trace}")
+
+
 @app.get("/kb/graph/{kb_name}")
 async def get_knowledge_graph(kb_name: str):
     """获取指定知识库的完整图谱"""
@@ -356,7 +371,15 @@ async def delete_knowledge_base(kb_name: str):
             
         success = rag_service.delete_knowledge_base(kb_name)
         if success:
-            return {"status": "success", "message": f"成功删除知识库：{kb_name}"}
+            try:
+                graph_deleted = _get_graph_service().delete_graph(kb_name)
+            except Exception:
+                graph_deleted = False
+            return {
+                "status": "success",
+                "message": f"成功删除知识库：{kb_name}",
+                "graph_deleted": graph_deleted,
+            }
         else:
             raise HTTPException(status_code=404, detail=f"知识库 {kb_name} 不存在")
     except Exception as e:

--- a/core/graph/service.py
+++ b/core/graph/service.py
@@ -23,6 +23,17 @@ class GraphQueryService:
             return None
         return graph.to_dict()
 
+    def delete_graph(self, kb_id: str) -> bool:
+        """删除指定知识库的完整图谱。
+
+        Args:
+            kb_id: 知识库 ID。
+
+        Returns:
+            是否确实删除了图谱。
+        """
+        return self._store.delete(kb_id)
+
     def list_entities(
         self,
         kb_id: str,

--- a/tests/test_graph_delete.py
+++ b/tests/test_graph_delete.py
@@ -1,0 +1,71 @@
+"""知识图谱删除能力离线单元测试。"""
+
+import pytest
+
+from core.graph import (
+    Entity,
+    GraphQueryService,
+    GraphStore,
+    InMemoryGraphStore,
+    KnowledgeGraph,
+    Relation,
+    SqliteGraphStore,
+)
+
+
+def make_store(backend: str, tmp_path) -> GraphStore:
+    """创建待测试的图谱存储后端。"""
+    if backend == "memory":
+        return InMemoryGraphStore()
+    return SqliteGraphStore(str(tmp_path / "graph.db"))
+
+
+def make_graph() -> KnowledgeGraph:
+    """构造包含实体和关系的最小图谱。"""
+    graph = KnowledgeGraph()
+    graph.add_entity(
+        Entity(
+            id="entity-1",
+            name="OpenAI",
+            type="company",
+            source_chunk_ids=["chunk-1"],
+        )
+    )
+    graph.add_entity(Entity(id="entity-2", name="GPT", type="model"))
+    graph.add_relation(
+        Relation(
+            id="relation-1",
+            source_entity_id="entity-1",
+            target_entity_id="entity-2",
+            type="develops",
+            weight=0.9,
+        )
+    )
+    return graph
+
+
+@pytest.mark.parametrize("backend", ["memory", "sqlite"])
+def test_delete_graph_hit_and_missing(backend: str, tmp_path) -> None:
+    """删除已存在图谱生效，删除缺失图谱返回 False。"""
+    store = make_store(backend, tmp_path)
+    store.save(make_graph(), "kb-1")
+    service = GraphQueryService(store)
+
+    assert service.delete_graph("kb-1") is True
+    assert service.get_graph("kb-1") is None
+    assert service.list_entities("kb-1") == {"items": [], "total": 0}
+    assert service.delete_graph("kb-1") is False
+
+
+def test_sqlite_delete_persists_across_store_instances(tmp_path) -> None:
+    """SQLite 图谱删除后，新实例读取仍为空。"""
+    db_path = str(tmp_path / "graph.db")
+    store_a = SqliteGraphStore(db_path)
+    store_a.save(make_graph(), "kb-1")
+    service_a = GraphQueryService(store_a)
+
+    assert service_a.delete_graph("kb-1") is True
+
+    store_b = SqliteGraphStore(db_path)
+    service_b = GraphQueryService(store_b)
+    assert service_b.get_graph("kb-1") is None


### PR DESCRIPTION
## 阶段B step6：图谱删除联动（每日一个可控增量）

堆叠于 #31 之上（链：#26 → #27 → #28 → #29 → #30 → #31 → 本PR）。

### 改动（3 文件，+86/-1）
- `core/graph/service.py`：`GraphQueryService.delete_graph(kb_id) -> bool`，委托存储层 `delete()`
- `app.py`：
  - 新增 `DELETE /kb/graph/{kb_name}`：图谱不存在 → 404；成功 → success 响应；异常处理与现有图谱端点同模式
  - `DELETE /kb/delete/{kb_name}` 联动：KB 删除成功后尽力清理图谱（异常吞掉不阻断），响应新增 `graph_deleted` 字段
- `tests/test_graph_delete.py`（新建）：纯离线测试，memory+sqlite 双后端参数化；覆盖已存在删除/缺失返回 False/SQLite 跨实例落盘删除

### 验证证据（编排器独立复跑，2026-09-07 02:5x UTC）
- **pytest**: `60 passed in 0.80s`（57 存量 + 3 新增，零失败）
- **flake8**: 仓库总数 `2902` 与基线完全持平；`app.py` `186` 不变；`tests/test_graph_delete.py` + `core/graph/service.py` 均 `0` 告警
- **py_compile**: `app.py`/`service.py`/`test_graph_delete.py` 全部 OK
- **Playwright/npm**: 不适用（纯后端改动，未触及前端）
- 生成方式：Codex（`codex exec --yolo -m gpt-5.3-codex`），单轮完成，未执行 git/pytest（由编排器统一闸门）

### 合并顺序建议
#26 → #27 → #28 → #29 → #30 → #31 → 本PR（依次合并后逐层自动去堆叠）