### PR TITLE
feat(draft): 阶段B step8 - 图谱端点 OpenAPI 元数据补全（summary + tags）

### DIFF
--- a/app.py
+++ b/app.py
@@ -221,7 +221,11 @@ async def get_knowledge_base_info(kb_name: str):
         raise HTTPException(status_code=500, detail=f"获取知识库信息失败: {str(e)}\n{error_trace}")
 
 
-@app.delete("/kb/graph/{kb_name}")
+@app.delete(
+    "/kb/graph/{kb_name}",
+    summary="删除指定知识库的完整图谱",
+    tags=["knowledge-graph"],
+)
 async def delete_knowledge_graph(kb_name: str):
     """删除指定知识库的完整图谱"""
     try:
@@ -236,7 +240,11 @@ async def delete_knowledge_graph(kb_name: str):
         raise HTTPException(status_code=500, detail=f"删除知识图谱失败: {str(e)}\n{error_trace}")
 
 
-@app.get("/kb/graph/{kb_name}")
+@app.get(
+    "/kb/graph/{kb_name}",
+    summary="获取指定知识库的完整图谱",
+    tags=["knowledge-graph"],
+)
 async def get_knowledge_graph(kb_name: str):
     """获取指定知识库的完整图谱"""
     try:
@@ -251,7 +259,11 @@ async def get_knowledge_graph(kb_name: str):
         raise HTTPException(status_code=500, detail=f"获取知识图谱失败: {str(e)}\n{error_trace}")
 
 
-@app.get("/kb/graph/{kb_name}/entities")
+@app.get(
+    "/kb/graph/{kb_name}/entities",
+    summary="分页查询图谱实体",
+    tags=["knowledge-graph"],
+)
 async def list_graph_entities(
     kb_name: str,
     type: Optional[str] = Query(None),
@@ -273,7 +285,11 @@ async def list_graph_entities(
         raise HTTPException(status_code=500, detail=f"查询图谱实体失败: {str(e)}\n{error_trace}")
 
 
-@app.get("/kb/graph/{kb_name}/entities/{entity_id}")
+@app.get(
+    "/kb/graph/{kb_name}/entities/{entity_id}",
+    summary="查询实体详情及一度关系",
+    tags=["knowledge-graph"],
+)
 async def get_graph_entity(
     kb_name: str,
     entity_id: str,
@@ -296,7 +312,11 @@ async def get_graph_entity(
         raise HTTPException(status_code=500, detail=f"查询图谱实体详情失败: {str(e)}\n{error_trace}")
 
 
-@app.get("/kb/graph/{kb_name}/relations")
+@app.get(
+    "/kb/graph/{kb_name}/relations",
+    summary="分页查询图谱关系",
+    tags=["knowledge-graph"],
+)
 async def list_graph_relations(
     kb_name: str,
     entity_id: Optional[str] = Query(None),
@@ -318,7 +338,11 @@ async def list_graph_relations(
         raise HTTPException(status_code=500, detail=f"查询图谱关系失败: {str(e)}\n{error_trace}")
 
 
-@app.post("/kb/graph/{kb_name}/extract")
+@app.post(
+    "/kb/graph/{kb_name}/extract",
+    summary="从知识库文本构建知识图谱",
+    tags=["knowledge-graph"],
+)
 async def extract_knowledge_graph(
     kb_name: str,
     max_chunks: int = Query(0, ge=0),


### PR DESCRIPTION
## 阶段B step8：知识图谱 API OpenAPI 元数据补全

堆叠于 #33（step7）之上，PR 栈：#26 → #27 → #28 → #29 → #30 → #31 → #32 → #33 → **本 PR**

### 改动内容（仅 app.py，+30/-6）
为 6 个知识图谱端点的装饰器补全 OpenAPI 路由元数据，`/docs` Swagger UI 中可按标签分组并显示中文摘要：
- `DELETE /kb/graph/{kb_name}` → summary="删除指定知识库的完整图谱"
- `GET /kb/graph/{kb_name}` → summary="获取指定知识库的完整图谱"
- `GET /kb/graph/{kb_name}/entities` → summary="分页查询图谱实体"
- `GET /kb/graph/{kb_name}/entities/{entity_id}` → summary="查询实体详情及一度关系"
- `GET /kb/graph/{kb_name}/relations` → summary="分页查询图谱关系"
- `POST /kb/graph/{kb_name}/extract` → summary="从知识库文本构建知识图谱"
- 全部 6 端点统一 `tags=["knowledge-graph"]`

纯文档元数据，**不改变任何业务逻辑、函数体与 docstring**。

### ✅ 验证证据（编排器独立复跑，2026-09-09 02:45 UTC）
| 闸门 | 结果 | 基线 |
|---|---|---|
| pytest | **60 passed** in 0.71s | 60（持平）|
| flake8 app.py | **186** | 186（零新增）|
| flake8 全仓 | **2902** | 2902（零新增）|
| py_compile | **OK** | — |
| git diff 范围 | 仅 app.py，6 处装饰器 hunk | — |
| Playwright | 不适用（纯后端元数据，无前端改动） | — |

### 生成方式
- Codex（`gpt-5.3-codex`）单轮完成，997 tokens，未执行任何 git 写操作
- 任务书约束生效：仅动 6 个装饰器，函数体/其他文件零改动