### PR TITLE
feat(draft): 阶段B step9 - FastAPI openapi_tags 全局元数据（knowledge-graph 分组中文说明）

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,7 +135,19 @@ class ChatQuery(BaseModel):
     temperature: float = 0.1
 
 # 初始化FastAPI应用
-app = FastAPI(title="知识库管理API", description="提供知识库管理和检索的RESTful API")
+TAGS_METADATA = [
+    {
+        "name": "knowledge-graph",
+        "description": "实验性知识图谱功能：实体/关系抽取、查询、构建触发、删除联动等",
+        "order": 999,
+    }
+]
+
+app = FastAPI(
+    title="知识库管理API",
+    description="提供知识库管理和检索的RESTful API",
+    openapi_tags=TAGS_METADATA,
+)
 
 # 添加CORS中间件
 app.add_middleware(


### PR DESCRIPTION
## 阶段B step9（每日一个可控增量，堆叠于 #34 之上）

## 改动
- 仅 `app.py`（+13/-1，commit a8b1d5f1）
- 新增模块级 `TAGS_METADATA`：`knowledge-graph` 标签中文说明（实验性知识图谱功能：实体/关系抽取、查询、构建触发、删除联动等），`order=999` 置于分组末尾
- `FastAPI(...)` 接入 `openapi_tags=TAGS_METADATA`；Swagger UI 图谱分组显示中文说明
- 纯文档元数据，零业务逻辑/路由/响应结构改动；未动任何端点装饰器

## 验证证据（编排器独立复跑，2026-09-10 02:4x UTC）
- `pytest -q`: **60 passed in 0.84s**（与基线持平）
- `flake8 app.py`: **186** / 全仓 **2902** —— 与基线完全一致，零新增
- `python3 -m py_compile app.py`: OK
- OpenAPI schema 实测：AST 提取 app.py 真实 `TAGS_METADATA` 构建 FastAPI(fastapi 0.141.1)，`openapi()["tags"] == TAGS_METADATA` ✅
- `git status`: 仅 `app.py`；Playwright 冒烟不适用（纯后端元数据，无前端改动）
- 代码由 Codex（`codex exec --yolo -m gpt-5.3-codex`）生成，EXIT=0，996 tokens，未做 git 写操作

## 合并顺序
#26 → #27 → … → #34 → **#35(本 PR)**