### PR TITLE
feat(draft): 阶段B step10 - 图谱端点 OpenAPI 错误响应描述（responses 元数据）

### DIFF
--- a/app.py
+++ b/app.py
@@ -237,6 +237,16 @@ async def get_knowledge_base_info(kb_name: str):
     "/kb/graph/{kb_name}",
     summary="删除指定知识库的完整图谱",
     tags=["knowledge-graph"],
+    responses={
+        "404": {
+            "description": "图谱不存在",
+            "content": {"application/json": {"example": {"detail": "知识库 xxx 的图谱不存在"}}},
+        },
+        "500": {
+            "description": "服务器内部错误",
+            "content": {"application/json": {"example": {"detail": "删除知识图谱失败"}}},
+        },
+    },
 )
 async def delete_knowledge_graph(kb_name: str):
     """删除指定知识库的完整图谱"""
@@ -256,6 +266,16 @@ async def delete_knowledge_graph(kb_name: str):
     "/kb/graph/{kb_name}",
     summary="获取指定知识库的完整图谱",
     tags=["knowledge-graph"],
+    responses={
+        "404": {
+            "description": "图谱不存在",
+            "content": {"application/json": {"example": {"detail": "知识库 xxx 的图谱不存在"}}},
+        },
+        "500": {
+            "description": "服务器内部错误",
+            "content": {"application/json": {"example": {"detail": "获取知识图谱失败"}}},
+        },
+    },
 )
 async def get_knowledge_graph(kb_name: str):
     """获取指定知识库的完整图谱"""
@@ -275,6 +295,12 @@ async def get_knowledge_graph(kb_name: str):
     "/kb/graph/{kb_name}/entities",
     summary="分页查询图谱实体",
     tags=["knowledge-graph"],
+    responses={
+        "500": {
+            "description": "服务器内部错误",
+            "content": {"application/json": {"example": {"detail": "查询图谱实体失败"}}},
+        },
+    },
 )
 async def list_graph_entities(
     kb_name: str,
@@ -301,6 +327,16 @@ async def list_graph_entities(
     "/kb/graph/{kb_name}/entities/{entity_id}",
     summary="查询实体详情及一度关系",
     tags=["knowledge-graph"],
+    responses={
+        "404": {
+            "description": "实体不存在",
+            "content": {"application/json": {"example": {"detail": "实体 xxx 不存在"}}},
+        },
+        "500": {
+            "description": "服务器内部错误",
+            "content": {"application/json": {"example": {"detail": "查询图谱实体详情失败"}}},
+        },
+    },
 )
 async def get_graph_entity(
     kb_name: str,
@@ -328,6 +364,12 @@ async def get_graph_entity(
     "/kb/graph/{kb_name}/relations",
     summary="分页查询图谱关系",
     tags=["knowledge-graph"],
+    responses={
+        "500": {
+            "description": "服务器内部错误",
+            "content": {"application/json": {"example": {"detail": "查询图谱关系失败"}}},
+        },
+    },
 )
 async def list_graph_relations(
     kb_name: str,
@@ -354,6 +396,20 @@ async def list_graph_relations(
     "/kb/graph/{kb_name}/extract",
     summary="从知识库文本构建知识图谱",
     tags=["knowledge-graph"],
+    responses={
+        "404": {
+            "description": "知识库不存在",
+            "content": {"application/json": {"example": {"detail": "知识库 xxx 不存在"}}},
+        },
+        "400": {
+            "description": "无可用文本块/抽取参数错误",
+            "content": {"application/json": {"example": {"detail": "知识库 xxx 中没有可用的文本块或抽取参数错误"}}},
+        },
+        "500": {
+            "description": "抽取失败",
+            "content": {"application/json": {"example": {"detail": "图谱抽取失败"}}},
+        },
+    },
 )
 async def extract_knowledge_graph(
     kb_name: str,


### PR DESCRIPTION
## 阶段B 知识图谱 step10（每日一个可控增量）

> 堆叠链：#26 → #27 → #28 → #29 → #30 → #31 → #32 → #33 → #34 → #35 → **本 PR**
> Base: `feat/kg-phase-b-step9-20260910`（#35），合入顺序遵循堆叠链。

## 改动内容
- 仅改 `app.py`（+72/-0，commit `6d2032a5`），为 6 个 `knowledge-graph` 端点装饰器新增 `responses=` 错误响应元数据，状态码与函数体实际 `HTTPException` 一一对应：
  - `DELETE /kb/graph/{kb_name}` → 404/500
  - `GET /kb/graph/{kb_name}` → 404/500
  - `GET /kb/graph/{kb_name}/entities` → 500
  - `GET /kb/graph/{kb_name}/entities/{entity_id}` → 404/500
  - `GET /kb/graph/{kb_name}/relations` → 500
  - `POST /kb/graph/{kb_name}/extract` → 400/404/500
- 每个 status code 含中文 `description` + `application/json` `example`（`{"detail": ...}`，与实际错误消息语义一致）
- 纯 OpenAPI 文档元数据，零业务逻辑改动，Swagger UI 可展示错误响应示例

## 验证证据（编排器独立复跑，Codex gpt-5.3-codex 生成 / 编排器复核）
| 闸门 | 结果 |
|---|---|
| `python3 -m py_compile app.py` | ✅ OK |
| `flake8 app.py` | ✅ 186（基线 186，零新增） |
| `flake8 .`（全仓） | ✅ 2902（基线 2902，零新增） |
| `python3 -m pytest -q` | ✅ 60 passed in 0.97s（持平） |
| `git diff --check` | ✅ 干净 |
| AST 一致性校验 | ✅ 6/6 端点 responses 键 == 实际 raise 的 status_code 集合 |
| FastAPI OpenAPI 冒烟 | ✅ 同构 responses 构建 schema：`['200','404','422','500']`，中文 example 正确落 schema |
| Playwright | N/A（纯后端元数据，无前端改动） |

## 说明
- 本仓 `faiss`/`modelscope` 缺失无法直接 `import app`，故 OpenAPI 验证采用 AST 提取 + FastAPI 0.141.1 同构构建法（与 step9 相同口径）。