### PR TITLE
feat(draft): 阶段B step11 - 图谱端点 Pydantic response_model 响应模型

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from pydantic import BaseModel
+from core.graph import schemas as graph_schemas  # noqa: E402
 
 # 确保当前目录在sys.path中
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -235,6 +236,7 @@ async def get_knowledge_base_info(kb_name: str):
 
 @app.delete(
     "/kb/graph/{kb_name}",
+    response_model=graph_schemas.GraphDeleteResponse,
     summary="删除指定知识库的完整图谱",
     tags=["knowledge-graph"],
     responses={
@@ -264,6 +266,7 @@ async def delete_knowledge_graph(kb_name: str):
 
 @app.get(
     "/kb/graph/{kb_name}",
+    response_model=graph_schemas.GraphDataResponse,
     summary="获取指定知识库的完整图谱",
     tags=["knowledge-graph"],
     responses={
@@ -293,6 +296,7 @@ async def get_knowledge_graph(kb_name: str):
 
 @app.get(
     "/kb/graph/{kb_name}/entities",
+    response_model=graph_schemas.GraphEntityListResponse,
     summary="分页查询图谱实体",
     tags=["knowledge-graph"],
     responses={
@@ -325,6 +329,7 @@ async def list_graph_entities(
 
 @app.get(
     "/kb/graph/{kb_name}/entities/{entity_id}",
+    response_model=graph_schemas.GraphEntityDetailResponse,
     summary="查询实体详情及一度关系",
     tags=["knowledge-graph"],
     responses={
@@ -362,6 +367,7 @@ async def get_graph_entity(
 
 @app.get(
     "/kb/graph/{kb_name}/relations",
+    response_model=graph_schemas.GraphRelationListResponse,
     summary="分页查询图谱关系",
     tags=["knowledge-graph"],
     responses={
@@ -394,6 +400,7 @@ async def list_graph_relations(
 
 @app.post(
     "/kb/graph/{kb_name}/extract",
+    response_model=graph_schemas.GraphBuildResponse,
     summary="从知识库文本构建知识图谱",
     tags=["knowledge-graph"],
     responses={

--- a/core/graph/schemas.py
+++ b/core/graph/schemas.py
@@ -1,0 +1,84 @@
+"""知识图谱接口响应模型。"""
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel
+
+
+class GraphEntityResponse(BaseModel):
+    """表示图谱实体接口响应。"""
+
+    id: str
+    name: str
+    type: str
+    properties: Dict[str, Any]
+    source_chunk_ids: List[str]
+
+
+class GraphRelationResponse(BaseModel):
+    """表示图谱关系接口响应。"""
+
+    id: str
+    source_entity_id: str
+    target_entity_id: str
+    type: str
+    properties: Dict[str, Any]
+    weight: float
+
+
+class GraphDataResponse(BaseModel):
+    """表示完整图谱接口响应。"""
+
+    entities: List[GraphEntityResponse]
+    relations: List[GraphRelationResponse]
+
+
+class GraphDeleteResponse(BaseModel):
+    """表示删除图谱接口响应。"""
+
+    status: str
+    message: str
+
+
+class GraphEntityListResponse(BaseModel):
+    """表示实体列表接口响应。"""
+
+    items: List[GraphEntityResponse]
+    total: int
+
+
+class GraphEntityDetailResponse(BaseModel):
+    """表示实体详情接口响应。"""
+
+    entity: GraphEntityResponse
+    relations: List[GraphRelationResponse]
+    total: int
+
+
+class GraphRelationListResponse(BaseModel):
+    """表示关系列表接口响应。"""
+
+    items: List[GraphRelationResponse]
+    total: int
+
+
+class GraphBuildStats(BaseModel):
+    """表示图谱构建统计信息。"""
+
+    kb_name: str
+    chunks_total: int
+    entities: int
+    relations: int
+    total_chunks: int
+    succeeded_chunks: int
+    failed_chunks: List[str]
+    chunk_errors: Dict[str, str]
+    total_entities: int
+    total_relations: int
+
+
+class GraphBuildResponse(BaseModel):
+    """表示图谱构建接口响应。"""
+
+    status: str
+    data: GraphBuildStats


### PR DESCRIPTION
## 变更（每日一个可控增量，栈层第 11 层，基于 step10 #36）
- 新增 `core/graph/schemas.py`（+84 行，9 个 Pydantic 模型）：GraphEntityResponse / GraphRelationResponse / GraphDataResponse / GraphDeleteResponse / GraphEntityListResponse / GraphEntityDetailResponse / GraphRelationListResponse / GraphBuildStats / GraphBuildResponse
- `app.py` +7/-0：模块级导入 `from core.graph import schemas as graph_schemas`（`# noqa: E402`，与同区块既有 import 一致）；6 个图谱端点装饰器接入 `response_model=`
- 端点映射：DELETE graph→GraphDeleteResponse；GET graph→GraphDataResponse；GET entities→GraphEntityListResponse；GET entity 详情→GraphEntityDetailResponse；GET relations→GraphRelationListResponse；POST extract→GraphBuildResponse
- 模型字段与 `GraphQueryService`/`GraphBuildService` 运行时 dict 形状逐键一致，零业务逻辑改动

## 验证证据（编排器独立复跑，FastAPI 0.141.1 / Pydantic 2.13.4 / Python 3.11）
- ✅ `pytest tests/ -q` → **60 passed**（与基线持平）
- ✅ `flake8 app.py` → **186**（基线 186，零新增）；`flake8 core/graph/schemas.py` → **0**；全仓 **2902**（基线持平）
- ✅ `py_compile app.py core/graph/schemas.py` 通过；`git diff --check` 干净
- ✅ **序列化等价校验**（本步核心风险点：response_model 会改运行时序列化）：真实 `GraphQueryService`+`SqliteGraphStore` 造数（含中文 properties、float weight），同构 FastAPI 应用挂接同一批模型 + TestClient 实测，6/6 端点响应与原 dict 经 `JSONResponse` 渲染**逐字节等价**；中文 properties、weight=1.5 保真
- ✅ AST 核对：app.py 6/6 图谱端点 `response_model` 引用与映射表一致
- ✅ OpenAPI 实测：6 端点 200 响应 `$ref` 全部指向新模型；`weight` → `{"type": "number"}`（Pydantic v2/OpenAPI 3.1 规范形态）
- ▶️ Playwright 冒烟：不适用（纯后端元数据/模型层改动）
- 代码由 Codex（gpt-5.3-codex，`codex exec --yolo`）单轮生成，14,190 tokens，未执行 git 写操作；以上闸门为编排器独立复跑结果

## 栈信息
- 合并顺序：#26 → #27 → … → #36 → **#37（本 PR）**；base=feat/kg-phase-b-step10-20260911
- main 仍为 5b33f42（rebase 未触发）

## 风险与回滚
- 单 commit 9dce8c4e，revert 即回滚；无 DB/接口签名变化；响应 JSON 已证逐字节不变