### PR TITLE
feat(draft): 阶段B step12 - 图谱端点响应模型 OpenAPI example 示例值

### DIFF
--- a/core/graph/schemas.py
+++ b/core/graph/schemas.py
@@ -2,11 +2,23 @@
 
 from typing import Any, Dict, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class GraphEntityResponse(BaseModel):
     """表示图谱实体接口响应。"""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "ent-001",
+                "name": "张三",
+                "type": "人物",
+                "properties": {"职位": "算法工程师"},
+                "source_chunk_ids": ["chunk-001", "chunk-002"],
+            }
+        }
+    )
 
     id: str
     name: str
@@ -17,6 +29,19 @@ class GraphEntityResponse(BaseModel):
 
 class GraphRelationResponse(BaseModel):
     """表示图谱关系接口响应。"""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "rel-001",
+                "source_entity_id": "ent-001",
+                "target_entity_id": "ent-002",
+                "type": "任职于",
+                "properties": {"职位": "首席科学家"},
+                "weight": 1.5,
+            }
+        }
+    )
 
     id: str
     source_entity_id: str
@@ -29,12 +54,54 @@ class GraphRelationResponse(BaseModel):
 class GraphDataResponse(BaseModel):
     """表示完整图谱接口响应。"""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "entities": [
+                    {
+                        "id": "ent-001",
+                        "name": "张三",
+                        "type": "人物",
+                        "properties": {"职位": "算法工程师"},
+                        "source_chunk_ids": ["chunk-001", "chunk-002"],
+                    },
+                    {
+                        "id": "ent-002",
+                        "name": "贝塔科技",
+                        "type": "公司",
+                        "properties": {"成立年份": 2015},
+                        "source_chunk_ids": ["chunk-003"],
+                    },
+                ],
+                "relations": [
+                    {
+                        "id": "rel-001",
+                        "source_entity_id": "ent-001",
+                        "target_entity_id": "ent-002",
+                        "type": "任职于",
+                        "properties": {"职位": "首席科学家"},
+                        "weight": 1.5,
+                    }
+                ],
+            }
+        }
+    )
+
     entities: List[GraphEntityResponse]
     relations: List[GraphRelationResponse]
 
 
 class GraphDeleteResponse(BaseModel):
     """表示删除图谱接口响应。"""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "status": "success",
+                "message": "图谱删除成功",
+            }
+        }
+    )
 
     status: str
     message: str
@@ -43,12 +110,61 @@ class GraphDeleteResponse(BaseModel):
 class GraphEntityListResponse(BaseModel):
     """表示实体列表接口响应。"""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "items": [
+                    {
+                        "id": "ent-001",
+                        "name": "张三",
+                        "type": "人物",
+                        "properties": {"职位": "算法工程师"},
+                        "source_chunk_ids": ["chunk-001", "chunk-002"],
+                    },
+                    {
+                        "id": "ent-002",
+                        "name": "贝塔科技",
+                        "type": "公司",
+                        "properties": {"成立年份": 2015},
+                        "source_chunk_ids": ["chunk-003"],
+                    },
+                ],
+                "total": 2,
+            }
+        }
+    )
+
     items: List[GraphEntityResponse]
     total: int
 
 
 class GraphEntityDetailResponse(BaseModel):
     """表示实体详情接口响应。"""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "entity": {
+                    "id": "ent-001",
+                    "name": "张三",
+                    "type": "人物",
+                    "properties": {"职位": "算法工程师"},
+                    "source_chunk_ids": ["chunk-001", "chunk-002"],
+                },
+                "relations": [
+                    {
+                        "id": "rel-001",
+                        "source_entity_id": "ent-001",
+                        "target_entity_id": "ent-002",
+                        "type": "任职于",
+                        "properties": {"职位": "首席科学家"},
+                        "weight": 1.5,
+                    }
+                ],
+                "total": 1,
+            }
+        }
+    )
 
     entity: GraphEntityResponse
     relations: List[GraphRelationResponse]
@@ -58,12 +174,47 @@ class GraphEntityDetailResponse(BaseModel):
 class GraphRelationListResponse(BaseModel):
     """表示关系列表接口响应。"""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "items": [
+                    {
+                        "id": "rel-001",
+                        "source_entity_id": "ent-001",
+                        "target_entity_id": "ent-002",
+                        "type": "任职于",
+                        "properties": {"职位": "首席科学家"},
+                        "weight": 1.5,
+                    }
+                ],
+                "total": 1,
+            }
+        }
+    )
+
     items: List[GraphRelationResponse]
     total: int
 
 
 class GraphBuildStats(BaseModel):
     """表示图谱构建统计信息。"""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "kb_name": "产品知识库",
+                "chunks_total": 10,
+                "entities": 12,
+                "relations": 18,
+                "total_chunks": 10,
+                "succeeded_chunks": 9,
+                "failed_chunks": ["chunk-010"],
+                "chunk_errors": {"chunk-010": "文档解析失败"},
+                "total_entities": 12,
+                "total_relations": 18,
+            }
+        }
+    )
 
     kb_name: str
     chunks_total: int
@@ -79,6 +230,26 @@ class GraphBuildStats(BaseModel):
 
 class GraphBuildResponse(BaseModel):
     """表示图谱构建接口响应。"""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "status": "success",
+                "data": {
+                    "kb_name": "产品知识库",
+                    "chunks_total": 10,
+                    "entities": 12,
+                    "relations": 18,
+                    "total_chunks": 10,
+                    "succeeded_chunks": 9,
+                    "failed_chunks": ["chunk-010"],
+                    "chunk_errors": {"chunk-010": "文档解析失败"},
+                    "total_entities": 12,
+                    "total_relations": 18,
+                },
+            }
+        }
+    )
 
     status: str
     data: GraphBuildStats


### PR DESCRIPTION
## 变更内容（阶段B step12，每日一个可控增量）
- 仅改 `core/graph/schemas.py`（+172/-1）：为 9 个 Pydantic 响应模型补 `model_config = ConfigDict(json_schema_extra={"example": ...})`，示例为真实感中文数据
- 纯 schema 元数据变更，不改运行时序列化；栈位：#37 之上（#26→#27→…→#37→本PR）

## 与前序步骤互补
- step10（#36）错误响应 responses 元数据 + step11（#37）response_model → 本步补成功示例值，/docs 与 openapi.json 均可展示具体示例

## 验证证据（编排器独立复跑，非 Codex 自报）
- **pytest**: `60 passed in 0.77s`（持平基线）
- **flake8 基线对比**: `core/graph/schemas.py` 0 / `app.py` 186 / 全仓 2902 —— 三口径与基线完全一致，零新增
- **py_compile**: OK；`git diff --check`: 干净
- **序列化等价闸门**（step11 脚本复跑）：真实 GraphQueryService+SqliteGraphStore 造数，6/6 图谱端点响应与无 response_model 渲染**逐字节等价**（examples 仅 schema 元数据，不影响运行时）
- **OpenAPI examples 专项闸门**：9/9 模型 components.schemas 均含 `example`；每个 example 均通过对应模型 `model_validate`（结构真实有效）；GraphBuildStats 内部一致性（chunks_total=total_chunks、succeeded+failed=chunks_total 等）与列表 total=len(items) 全部通过；示例含 222 个中文字符（中文数据要求）
- **AST 接线核对**: 6/6 端点 response_model 引用不变（app.py 本步零改动）
- **Playwright**: 不适用（纯后端元数据增量）

## 生成方式
- Codex（`codex exec --yolo -m gpt-5.3-codex`）单轮完成，EXIT=0，6,213 tokens；仅改 schemas.py，无越权 git 操作